### PR TITLE
Update README Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
    npm ci
    ```
 
-1. Create a [Stedi account](https://www.stedi.com/auth/sign-up?).
+1. Create a [Stedi account](https://www.stedi.com/auth/sign-up).
 
 1. Rename the bootstrap's `.env.example` file to `.env` and update the following environment variables:
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,10 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
 
 1. Create a [Stedi account](https://www.stedi.com/auth/sign-up?).
 
- 1. [Generate an API Key](https://www.stedi.com/app/settings/api-keys). An API key is required to authenticate with Stedi APIs and deploy Stedi functions. 
-
-1. Go to [webhook.site](https://webhook.site/) and copy the unique URL. The bootstrap workflow sends output to this webhook.
-
 1. Rename the bootstrap's `.env.example` file to `.env` and update the following environment variables:
 
-   - `STEDI_API_KEY`: Your Stedi API Key
-   - `DESTINATION_WEBHOOK_URL`: the unique URL you copied from [webhook.site](https://webhook.site/)
+   - `STEDI_API_KEY`: A Stedi API key is required for authentication. You can [generate an API key](https://www.stedi.com/app/settings/api-keys) in your Stedi account. 
+   - `DESTINATION_WEBHOOK_URL`: Go to [webhook.site](https://webhook.site/) and copy the unique URL. The bootstrap workflow sends output to this webhook.
    
    Example `.env` file
    ```

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The bootstrap workflow uses the following process to handle incoming EDI:
 The bootstrap uses a similar process in reverse to handle outgoing EDI. It translates JSON documents to EDI and publishes them to a Stedi bucket.
 
 
-## Prerequisites & Deployment
+## Requirements
 
-1. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) _(minimum version: 15)_
+1. Install [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) _(minimum version: 15)_
 
-1. Clone this repo and install the necessary dependencies:
+1. Clone the bootstrap repository and install the necessary dependencies:
 
    ```bash
    git clone https://github.com/Stedi-Demos/bootstrap.git
@@ -27,27 +27,31 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
    npm ci
    ```
 
-1. Go to [webhook.site](https://webhook.site/) and copy the unique URL. The demo will send output to this webhook.
+1. Create a [Stedi account](https://www.stedi.com/auth/sign-up?) and [generate an API Key](https://www.stedi.com/app/settings/api-keys). An API key is required to authenticate with Stedi APIs and deploy Stedi functions. 
 
-1. This project uses `dotenv` to manage the environmental variables required. Rename the `.env.example` file to `.env` and amend the following variables:
+1. Go to [webhook.site](https://webhook.site/) and copy the unique URL. The bootstrap workflow sends output to this webhook.
 
-   - `STEDI_API_KEY`: Your Stedi API Key - used to deploy the function and internally to interact with product APIs. If you don't already have one, you can generate an [API Key here](https://www.stedi.com/app/settings/api-keys).
-   - `DESTINATION_WEBHOOK_URL`: the unique URL copied from [webhook.site](https://webhook.site/) in the previous step.
+1. Rename the bootstrap's `.env.example` file to `.env` and update the following environment variables:
 
-   Example `.env` file:
-
+   - `STEDI_API_KEY`: Your Stedi API Key
+   - `DESTINATION_WEBHOOK_URL`: the unique URL you copied from [webhook.site](https://webhook.site/)
+   
+   Example `.env` file
    ```
    STEDI_API_KEY=<YOUR_STEDI_API_KEY>
    DESTINATION_WEBHOOK_URL=<YOUR_WEBHOOK_URL>
    ```
 
-1. To deploy the components:
 
-   ```bash
-   npm run bootstrap
-   ```
+## Deploying the bootstrap
 
-## Testing the system
+Run the following command in the bootstrap directory: 
+
+```bash
+npm run bootstrap
+```
+
+## Testing the workflow
 
 ### Inbound EDI
 The `inbound-edi` function will be invoked automatically when files are written to the SFTP bucket.
@@ -346,7 +350,7 @@ The `outbound-edi` function can be invoked via the UI for testing.
 
 5. You can view the file using the [Buckets UI](https://www.stedi.com/app/buckets). As shown above, the output of the function includes the `bucketName` and `key` (path within the bucket) of where the generated EDI was saved.
 
-# Customizing the Bootstrap Workflow
+# Customizing the workflow
 
 The bootstrap workflow uses a sample trading partner to set up and test the read and write EDI workflows. You can customize the bootstrap workflow for your use case by doing one or all of the following:
 - [Edit the partner profile](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#add-a-trading-partner-profile) to replace the test trading partner with your real trading partners' details and requirements.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # Stedi EDI Bootstrap
 
-This repository contains an end-to-end configuration for building a full X12 EDI system using Stedi products. This implementation demonstrates one way to build an integration for the common read and write EDI use cases. Your solution may differ, depending on your systems and requirements. We encourage you to [contact us](mailto:support@stedi.com) as you get started with Stedi, so we can help you customize the workflow.
+This repository contains an end-to-end configuration for building a full X12 EDI system using Stedi products. This implementation demonstrates one way to build an integration for the common read and write EDI use cases. Your solution may differ, depending on your systems and requirements. 
 
+## Hands-On Support
 
-## Read and Write Workflow 
+We'd like to set up and customize the bootstrap repository with you. Working together helps us understand what Stedi customers need and helps get your solution into production as quickly as possible. We offer free hands-on support that includes:
+
+- Help deploying the bootstrap workflows and customizing them for your use cases
+- Best practices for designing a scalable Stedi integration
+- EDI experts to answer your questions
+- Live troubleshooting over slack or video call
+
+[Contact us](https://www.stedi.com/contact) to get started.
+
+## Bootstrap Read and Write Workflow 
 
 The bootstrap workflow uses the following process to handle incoming EDI:
 
@@ -52,9 +62,9 @@ npm run bootstrap
 ## Testing the workflows
 
 ### Inbound EDI
-The `inbound-edi` function will be invoked automatically when files are written to the SFTP bucket.
+New files in the SFTP bucket automatically invoke the `inbound-edi` function.
 
-1. Using the [Buckets UI](https://www.stedi.com/app/buckets) navigate to the `inbound` directory for your trading partner: `<SFTP_BUCKET_NAME>/trading_partners/ANOTHERMERCH/inbound`
+1. Go to the [Buckets UI](https://www.stedi.com/app/buckets) and navigate to the `inbound` directory for your trading partner: `<SFTP_BUCKET_NAME>/trading_partners/ANOTHERMERCH/inbound`
 
 2. Upload the [input X12 5010 855 EDI](src/resources/X12/5010/855/inbound.edi) document to this directory. (_note_: if you upload the document to any directory not named `inbound`, it will be intentionally ignored by the `inbound-edi`).
 
@@ -318,7 +328,7 @@ The `inbound-edi` function will be invoked automatically when files are written 
 
 ### Outbound EDI
 
-The `outbound-edi` function can be invoked via the UI for testing. 
+You can invoke the `outbound-edi` function through the UI for testing. 
 
 1. Navigate to the `outbound-edi` function in the [Functions UI][https://www.stedi.com/terminal/functions/edi-outbound/edit](https://www.stedi.com/app/functions).
 
@@ -350,12 +360,12 @@ The `outbound-edi` function can be invoked via the UI for testing.
 
 # Customizing the workflows
 
-The bootstrap workflow uses a sample trading partner to set up and test the read and write EDI workflows. You can customize the bootstrap workflow for your use case by doing one or all of the following:
+The bootstrap workflow uses a sample trading partner to set up and test the read and write EDI workflows. You can customize the bootstrap workflow by doing one or all of the following:
 - [Edit the partner profile](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#add-a-trading-partner-profile) to replace the test trading partner with your real trading partners' details and requirements.
 - [Create Stedi mappings](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#map-inbound-messages). The base bootstrap repository ingests and generates JSON with a schema that closely matches EDI documents. You may need to create a mapping to transform EDI documents into a custom JSON shape for your internal system. You can also create a mapping that transforms JSON data from your system into the JSON schema required for outgoing EDI documents.
 - [Create SFTP users](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#sending-and-receiving-documents-with-sftp) for your trading partners, so they can send and retrieve EDI documents from Stedi Buckets. 
 
-You may also want to add additional Stedi products to optimize your EDI workflows. We offer free hands-on troubleshooting and customized support to get your solution into production as quickly as possible. [Contact us](https://www.stedi.com/contact) to get started.
+You may want to use additional Stedi products to further optimize your EDI workflows. We can help you customize the bootstrap workflow and determine which products and approaches are right for your use cases. [Contact us](https://www.stedi.com/contact) to set up a meeting with our technical team.
 
 # Cleanup
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The `inbound-edi` function will be invoked automatically when files are written 
 
 The `outbound-edi` function can be invoked via the UI for testing. 
 
-1. Navigate to the `outbound-edi` function in the [Functions UI](https://www.stedi.com/terminal/functions/edi-outbound/edit).
+1. Navigate to the `outbound-edi` function in the [Functions UI][https://www.stedi.com/terminal/functions/edi-outbound/edit](https://www.stedi.com/app/functions).
 
 2. Click the `Edit execution payload` link, paste the contents of [src/resources/X12/5010/850/outbound.json](src/resources/X12/5010/850/outbound.json) into the payload modal, and click save.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
    ```
 
 
-## Deploying the bootstrap workflow
+## Deploying the bootstrap resources
 
 Run the following command in the bootstrap directory: 
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ The `outbound-edi` function can be invoked via the UI for testing.
 
 5. You can view the file using the [Buckets UI](https://www.stedi.com/app/buckets). As shown above, the output of the function includes the `bucketName` and `key` (path within the bucket) of where the generated EDI was saved.
 
-# Customizing the workflow
+# Customizing the workflows
 
 The bootstrap workflow uses a sample trading partner to set up and test the read and write EDI workflows. You can customize the bootstrap workflow for your use case by doing one or all of the following:
 - [Edit the partner profile](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#add-a-trading-partner-profile) to replace the test trading partner with your real trading partners' details and requirements.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
    ```
 
 
-## Deploying the bootstrap
+## Deploying the bootstrap workflow
 
 Run the following command in the bootstrap directory: 
 

--- a/README.md
+++ b/README.md
@@ -355,9 +355,11 @@ The bootstrap workflow uses a sample trading partner to set up and test the read
 - [Create Stedi mappings](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#map-inbound-messages). The base bootstrap repository ingests and generates JSON with a schema that closely matches EDI documents. You may need to create a mapping to transform EDI documents into a custom JSON shape for your internal system. You can also create a mapping that transforms JSON data from your system into the JSON schema required for outgoing EDI documents.
 - [Create SFTP users](https://www.stedi.com/docs/bootstrap/adjusting-the-workflow#sending-and-receiving-documents-with-sftp) for your trading partners, so they can send and retrieve EDI documents from Stedi Buckets. 
 
+You may also want to add additional Stedi products to optimize your EDI workflows. We offer free hands-on troubleshooting and customized support to get your solution into production as quickly as possible. [Contact us](https://www.stedi.com/contact) to get started.
+
 # Cleanup
 
-In order to delete all the resources created by the bootstrap, run the following command:
+To delete all the resources created by the bootstrap, run the following command:
 
 ```bash
 npm run destroy

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run the following command in the bootstrap directory:
 npm run bootstrap
 ```
 
-## Testing the workflow
+## Testing the workflows
 
 ### Inbound EDI
 The `inbound-edi` function will be invoked automatically when files are written to the SFTP bucket.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The bootstrap uses a similar process in reverse to handle outgoing EDI. It trans
    npm ci
    ```
 
-1. Create a [Stedi account](https://www.stedi.com/auth/sign-up?) and [generate an API Key](https://www.stedi.com/app/settings/api-keys). An API key is required to authenticate with Stedi APIs and deploy Stedi functions. 
+1. Create a [Stedi account](https://www.stedi.com/auth/sign-up?).
+
+ 1. [Generate an API Key](https://www.stedi.com/app/settings/api-keys). An API key is required to authenticate with Stedi APIs and deploy Stedi functions. 
 
 1. Go to [webhook.site](https://webhook.site/) and copy the unique URL. The bootstrap workflow sends output to this webhook.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We'd like to set up and customize the bootstrap repository with you. Working tog
 - Help deploying the bootstrap workflows and customizing them for your use cases
 - Best practices for designing a scalable Stedi integration
 - EDI experts to answer your questions
-- Live troubleshooting over slack or video call
+- Live troubleshooting over Slack or video call
 
 [Contact us](https://www.stedi.com/contact) to get started.
 


### PR DESCRIPTION
A couple more tiny nits for the README. I was reviewing it again today because I'm working on onboarding docs, and I noticed that we don't mention creating a Stedi account explicitly. Since the bootstrap is for new users, it seems possible that they may not have a Stedi account yet/not really understand that it's required for this bootstrap. I think it never hurts to be explicit!

I also just adjusted the requirements so they all start with action words and made a couple of other tiny tweaks. My goal is to make it easier to read/make things obvious for new users. For example, I think separating out deployment and requirements could be helpful, so I made that into a separate section. LMK if you disagree with any of these edits - thank you!