### PR TITLE
fix: include envelope data for processed inbound edi files

### DIFF
--- a/src/lib/deliverToDestination.ts
+++ b/src/lib/deliverToDestination.ts
@@ -5,6 +5,7 @@ import {
   PutObjectCommandInput,
 } from "@stedi/sdk-client-buckets";
 import { bucketClient } from "./buckets";
+import { invokeMapping } from "./mappings";
 
 const bucketsClient = bucketClient();
 
@@ -15,11 +16,19 @@ export type DeliveryResult = {
 
 export const deliverToDestination = async (
   destination: Destination["destination"],
-  payload: object | string
+  payload: object | string,
+  mappingId?: string,
 ): Promise<DeliveryResult> => {
   const result: DeliveryResult = { type: destination.type, payload: {} };
 
-  const body = typeof payload === "object" ? JSON.stringify(payload) : payload;
+  const destinationPayload = mappingId !== undefined
+    ? await invokeMapping(mappingId, payload)
+    : payload;
+
+  const body = typeof destinationPayload === "object"
+    ? JSON.stringify(destinationPayload)
+    : destinationPayload;
+
   switch (destination.type) {
     case "webhook":
       const params: RequestInit = {

--- a/src/lib/processEdi.ts
+++ b/src/lib/processEdi.ts
@@ -1,11 +1,9 @@
 import { translateEdiToJson } from "./translateV3.js";
 import { trackProgress } from "./progressTracking.js";
-import { invokeMapping } from "./mappings.js";
 
-export const processTransactionSet = async (
+export const processEdi = async (
   guideId: string,
   ediDocument: string,
-  mappingId?: string
 ): Promise<any> => {
   const translation = await translateEdiToJson(ediDocument, guideId);
   await trackProgress("translated edi document", translation);
@@ -17,7 +15,5 @@ export const processTransactionSet = async (
     throw new Error(`no transaction sets found in input`);
   }
 
-  return mappingId !== undefined
-    ? await invokeMapping(mappingId, { transactionSets: translation.transactionSets })
-    : translation;
+  return translation;
 };


### PR DESCRIPTION
- include envelope data when processing each inbound transaction set
- only invoke translate once per transaction set (not per destination)
- move mapping call to `deliverToDestination`
- fix input file deletion (only delete after entire file has been processed)

closes: #31 