### PR TITLE
fix: change profile id to profileId to match latest SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@stedi/sdk-client-functions": "^0.0.23",
         "@stedi/sdk-client-guides": "^0.0.46",
         "@stedi/sdk-client-mappings": "^0.0.46",
-        "@stedi/sdk-client-partners": "^0.1.5",
+        "@stedi/sdk-client-partners": "^0.1.15",
         "@stedi/sdk-client-sftp": "^0.0.46",
         "@stedi/sdk-client-stash": "^0.0.46",
         "@ts2asl/asl-lib": "^0.1.35",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/@stedi/sdk-client-partners": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.1.5.tgz",
-      "integrity": "sha512-ZgPqSTYiNBc6Kx5M2xQBdMSOd4logRuNNp35z5F4cDW1A3qFD8gDGiZML+rFxbsj/KHUIjqNZqYahBy15ASl4g==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.1.15.tgz",
+      "integrity": "sha512-+bbYSa/SA3QNqhFuxDksf1DWJvEZDCUvztb9jeaL+royt9jTcDW172MEBJIKpd12tEv1QytJWKr/EL1ebKX1bQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
@@ -8367,9 +8367,9 @@
       }
     },
     "@stedi/sdk-client-partners": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.1.5.tgz",
-      "integrity": "sha512-ZgPqSTYiNBc6Kx5M2xQBdMSOd4logRuNNp35z5F4cDW1A3qFD8gDGiZML+rFxbsj/KHUIjqNZqYahBy15ASl4g==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.1.15.tgz",
+      "integrity": "sha512-+bbYSa/SA3QNqhFuxDksf1DWJvEZDCUvztb9jeaL+royt9jTcDW172MEBJIKpd12tEv1QytJWKr/EL1ebKX1bQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@stedi/sdk-client-functions": "^0.0.23",
     "@stedi/sdk-client-guides": "^0.0.46",
     "@stedi/sdk-client-mappings": "^0.0.46",
-    "@stedi/sdk-client-partners": "^0.1.5",
+    "@stedi/sdk-client-partners": "^0.1.15",
     "@stedi/sdk-client-sftp": "^0.0.46",
     "@stedi/sdk-client-stash": "^0.0.46",
     "@ts2asl/asl-lib": "^0.1.35",

--- a/src/lib/loadPartnerProfile.ts
+++ b/src/lib/loadPartnerProfile.ts
@@ -24,7 +24,7 @@ export const loadPartnerProfile = async (
     // load x12 Trading Partner Profile (pre-GA)
     const profile = await partnersClient.send(
       new GetX12ProfileCommand({
-        id: partnerId,
+        profileId: partnerId,
       })
     );
 

--- a/src/lib/types/PartnerRouting.ts
+++ b/src/lib/types/PartnerRouting.ts
@@ -46,7 +46,7 @@ export const ISAPartnerIdLookupSchema = z.strictObject({
 export type ISAPartnerIdLookup = z.infer<typeof ISAPartnerIdLookupSchema>;
 
 export const PartnerProfileSchema = z.strictObject({
-  id: z.string(),
+  profileId: z.string(),
   partnerName: z.string(),
   acknowledgmentRequestedCode: z.string(),
   partnerInterchangeQualifier: z.string(),

--- a/src/setup/bootstrap/createProfiles.ts
+++ b/src/setup/bootstrap/createProfiles.ts
@@ -10,7 +10,7 @@ import { PARTNERS_KEYSPACE_NAME } from "../../lib/constants.js";
 export const createProfiles = async () => {
   const profiles = [
     {
-      id: "this-is-me",
+      profileId: "this-is-me",
       partnerName: "Me, Myself and I",
       partnerInterchangeQualifier: "ZZ",
       partnerInterchangeId: "THISISME",
@@ -18,7 +18,7 @@ export const createProfiles = async () => {
       partnerApplicationId: "MYAPPID",
     },
     {
-      id: "another-merchant",
+      profileId: "another-merchant",
       partnerName: "A.N. & Other Merchants",
       partnerInterchangeQualifier: "14",
       partnerInterchangeId: "ANOTHERMERCH",
@@ -58,7 +58,7 @@ export const createProfiles = async () => {
       await stashClient.send(
         new SetValueCommand({
           keyspaceName: PARTNERS_KEYSPACE_NAME,
-          key: `profile|${profile.id}`,
+          key: `profile|${profile.profileId}`,
           value: parseResult.data,
         })
       );


### PR DESCRIPTION
Not sure if we're keeping the bootstrap up to date, with this change we make sure if the `USE_BETA` flag
is used, the profile creation step wont fail.