### PR TITLE
feat: add support for user-defined headers and verbs for webhook destinations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@stedi/sdk-client-partners": "^0.1.5",
         "@stedi/sdk-client-sftp": "^0.0.46",
         "@stedi/sdk-client-stash": "^0.0.46",
-        "@stedi/x12-tools": "^1.2.0",
+        "@stedi/x12-tools": "^1.3.2",
         "@ts2asl/asl-lib": "^0.1.35",
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.2",
@@ -7350,9 +7350,9 @@
       }
     },
     "node_modules/@stedi/x12-tools": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@stedi/x12-tools/-/x12-tools-1.2.0.tgz",
-      "integrity": "sha512-iI0uS0iV8uQ8oxhUQ26MhnOHw+TJEkfB105AH+bv9/krtqCPCrUEwSht/b8PuVWy54VOvMqbPDwoENRpQ6joqg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stedi/x12-tools/-/x12-tools-1.3.2.tgz",
+      "integrity": "sha512-uqhdU2FsovL6Iecz4VRABPtAnNGtGbC0Bd27aG5lJsp0zmuqC8/1VhsD39Ww81E8sOmD1zu47h151uHjlzG9wA==",
       "dev": true
     },
     "node_modules/@ts2asl/asl-lib": {
@@ -16721,9 +16721,9 @@
       }
     },
     "@stedi/x12-tools": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@stedi/x12-tools/-/x12-tools-1.2.0.tgz",
-      "integrity": "sha512-iI0uS0iV8uQ8oxhUQ26MhnOHw+TJEkfB105AH+bv9/krtqCPCrUEwSht/b8PuVWy54VOvMqbPDwoENRpQ6joqg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@stedi/x12-tools/-/x12-tools-1.3.2.tgz",
+      "integrity": "sha512-uqhdU2FsovL6Iecz4VRABPtAnNGtGbC0Bd27aG5lJsp0zmuqC8/1VhsD39Ww81E8sOmD1zu47h151uHjlzG9wA==",
       "dev": true
     },
     "@ts2asl/asl-lib": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@stedi/sdk-client-partners": "^0.1.5",
     "@stedi/sdk-client-sftp": "^0.0.46",
     "@stedi/sdk-client-stash": "^0.0.46",
-    "@stedi/x12-tools": "^1.2.0",
+    "@stedi/x12-tools": "^1.3.2",
     "@ts2asl/asl-lib": "^0.1.35",
     "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.2",

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -6,7 +6,7 @@ import {
   DeleteObjectCommand,
   GetObjectCommand,
 } from "@stedi/sdk-client-buckets";
-import * as x12 from "@stedi/x12-tools/node.js";
+import * as x12 from "@stedi/x12-tools";
 
 import { processEdi } from "../../../lib/processEdi.js";
 import {

--- a/src/lib/acks.ts
+++ b/src/lib/acks.ts
@@ -1,4 +1,4 @@
-import * as x12 from "@stedi/x12-tools/node.js";
+import * as x12 from "@stedi/x12-tools";
 
 import { generateControlNumber } from "./generateControlNumber.js";
 import {
@@ -8,11 +8,10 @@ import {
   generateDestinationFilename
 } from "./destinations.js";
 import { AckTransactionSet, UsageIndicatorCodeSchema } from "./types/PartnerRouting.js";
-import { Interchange } from "@stedi/x12-tools/node.js";
 
 export type AckDeliveryInput = {
   ackTransactionSet: AckTransactionSet;
-  interchange: Interchange;
+  interchange: x12.Interchange;
   edi: string;
   sendingPartnerId: string;
   receivingPartnerId: string;

--- a/src/lib/destinations.ts
+++ b/src/lib/destinations.ts
@@ -45,7 +45,7 @@ export const deliverToDestination = async (
   switch (input.destination.type) {
     case "webhook":
       const params: RequestInit = {
-        method: "POST",
+        method: input.destination.verb,
         headers: {
           "Content-Type": "application/json",
           ...input.destination.headers,

--- a/src/lib/destinations.ts
+++ b/src/lib/destinations.ts
@@ -48,6 +48,7 @@ export const deliverToDestination = async (
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...input.destination.headers,
         },
         body,
       };

--- a/src/lib/types/PartnerRouting.ts
+++ b/src/lib/types/PartnerRouting.ts
@@ -111,6 +111,8 @@ export const PartnershipSchema = z.strictObject({
   transactionSets: z.array(TransactionSetSchema),
 });
 
+export type PartnershipInput = z.input<typeof PartnershipSchema>;
+
 export type Partnership = z.infer<typeof PartnershipSchema>;
 
 export const ISAPartnerIdLookupSchema = z.strictObject({

--- a/src/lib/types/PartnerRouting.ts
+++ b/src/lib/types/PartnerRouting.ts
@@ -11,6 +11,11 @@ export type UsageIndicatorCode = z.infer<typeof UsageIndicatorCodeSchema>;
 const DestinationWebhookSchema = z.strictObject({
   type: z.literal("webhook"),
   url: z.string(),
+  verb: z.enum([
+    "PATCH",
+    "POST",
+    "PUT",
+  ]).default("POST"),
   headers: z.record(
     // `Content-Type` header override is not allowed
     z.string().regex(/^(?!content-type).+$/i),

--- a/src/lib/types/PartnerRouting.ts
+++ b/src/lib/types/PartnerRouting.ts
@@ -11,6 +11,11 @@ export type UsageIndicatorCode = z.infer<typeof UsageIndicatorCodeSchema>;
 const DestinationWebhookSchema = z.strictObject({
   type: z.literal("webhook"),
   url: z.string(),
+  headers: z.record(
+    // `Content-Type` header override is not allowed
+    z.string().regex(/^(?!content-type).+$/i),
+    z.string()
+  ).optional(),
 });
 
 export const DestinationBucketSchema = z.strictObject({

--- a/src/setup/bootstrap/createStashRecords.ts
+++ b/src/setup/bootstrap/createStashRecords.ts
@@ -1,7 +1,7 @@
 import { SetValueCommand } from "@stedi/sdk-client-stash";
 import { PARTNERS_KEYSPACE_NAME } from "../../lib/constants.js";
 import { requiredEnvVar } from "../../lib/environment.js";
-import { Partnership } from "../../lib/types/PartnerRouting.js";
+import { PartnershipInput } from "../../lib/types/PartnerRouting.js";
 import { stashClient as buildStashClient } from "../../lib/stash.js";
 import { savePartnership } from "../../lib/savePartnership.js";
 
@@ -19,7 +19,7 @@ export const createSampleStashRecords = async ({
   const sftpBucketName = requiredEnvVar("SFTP_BUCKET_NAME");
   const outboundBucketPath = "trading_partners/ANOTHERMERCH/outbound";
 
-  const partnership: Partnership = {
+  const partnership: PartnershipInput = {
     transactionSets: [],
   };
 


### PR DESCRIPTION
I verified via the following stash config:

![image](https://user-images.githubusercontent.com/39536918/219100194-8be10781-c8af-4eca-bb55-2d4d171f3817.png)

... that the header gets added successfully: 

![image](https://user-images.githubusercontent.com/39536918/219100267-fb55301f-52a6-4dfe-b1c1-e67c23907943.png)

I also verified that attempting to set `content-type` was rejected by Zod:

```
INFO ZodError: [ { "validation": "regex", "code": "invalid_string", "message": "Invalid", "path": [ "transactionSets", 1, "destinations", 0, "destination", "headers", "content-type" ] } ]
```

I also tested all of the supported verbs:

![image](https://user-images.githubusercontent.com/39536918/219105166-06255cb0-345a-4104-90c9-1a5ea62f54cc.png)

Closes: #22 
