### PR TITLE
feat: add support for `sftp` destination

### DIFF
--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -124,8 +124,6 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
     const deliveryResults = await Promise.allSettled(
       transactionSetConfig.destinations.map(
         async ({ destination, mappingId }) => {
-          console.log(destination);
-
           const guideJson =
             mappingId !== undefined
               ? await invokeMapping(mappingId, outboundEvent.payload)

--- a/src/functions/ftp/external-poller/handler.ts
+++ b/src/functions/ftp/external-poller/handler.ts
@@ -17,7 +17,7 @@ import {
   RemotePollerConfig,
   RemotePollerConfigMap,
   RemotePollerConfigMapSchema,
-} from "../../../lib/types/RemotePollerConfig.js";
+} from "../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePollingResults } from "./types.js";
 import { RemotePoller } from "./pollers/remotePoller.js";
 import { FtpPoller } from "./pollers/ftpPoller.js";

--- a/src/functions/ftp/external-poller/pollers/ftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/ftpPoller.ts
@@ -7,7 +7,7 @@ import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
 import { bucketClient } from "../../../../lib/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
+import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 

--- a/src/functions/ftp/external-poller/pollers/ftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/ftpPoller.ts
@@ -8,7 +8,7 @@ import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 import { bucketClient } from "../../../../lib/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
 import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
-import { ConnectionDetails } from "../../../../lib/types/RemotePollerConfig.js";
+import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 
 export class FtpPoller extends RemotePoller {

--- a/src/functions/ftp/external-poller/pollers/remotePoller.ts
+++ b/src/functions/ftp/external-poller/pollers/remotePoller.ts
@@ -1,5 +1,5 @@
 import { FileDetails, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
+import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 
 export abstract class RemotePoller {

--- a/src/functions/ftp/external-poller/pollers/remotePoller.ts
+++ b/src/functions/ftp/external-poller/pollers/remotePoller.ts
@@ -1,6 +1,6 @@
 import { FileDetails, RemoteFileDetails } from "../types.js";
 import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
-import { ConnectionDetails } from "../../../../lib/types/RemotePollerConfig.js";
+import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 
 export abstract class RemotePoller {
   abstract getRemoteFileDetails(remotePath: string, remoteFiles?: string[]): Promise<RemoteFileDetails>;

--- a/src/functions/ftp/external-poller/pollers/sftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/sftpPoller.ts
@@ -5,7 +5,7 @@ import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
 import { bucketClient } from "../../../../lib/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
+import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 

--- a/src/functions/ftp/external-poller/pollers/sftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/sftpPoller.ts
@@ -6,7 +6,7 @@ import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 import { bucketClient } from "../../../../lib/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
 import { DestinationBucket } from "../../../../lib/types/PartnerRouting.js";
-import { ConnectionDetails } from "../../../../lib/types/RemotePollerConfig.js";
+import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 
 export class SftpPoller extends RemotePoller {

--- a/src/lib/destinations.ts
+++ b/src/lib/destinations.ts
@@ -7,7 +7,7 @@ import {
 
 import { bucketClient } from "./buckets.js";
 import { invokeMapping } from "./mappings.js";
-import { Destination } from "./types/PartnerRouting.js";
+import { Destination } from "./types/Destination.js";
 
 const bucketsClient = bucketClient();
 

--- a/src/lib/destinations.ts
+++ b/src/lib/destinations.ts
@@ -1,4 +1,5 @@
 import fetch, { RequestInit } from "node-fetch";
+import sftp from "ssh2-sftp-client";
 
 import {
   PutObjectCommand,
@@ -75,6 +76,23 @@ export const deliverToDestination = async (
       await bucketsClient.send(new PutObjectCommand(putCommandArgs));
 
       break;
+
+    case "sftp":
+      const filename = input.destinationFilename || `payload-${Date.now()}.out`;
+      const remotePath = `${input.destination.remotePath}/${filename}`;
+      const { host, username } = input.destination.connectionDetails;
+      const sftpClient = new sftp();
+      await sftpClient.connect(input.destination.connectionDetails);
+      await sftpClient.put(Buffer.from(body), remotePath);
+      await sftpClient.end();
+      result.payload = {
+        host,
+        username,
+        remotePath,
+        contents: body,
+      };
+      break;
+
     default:
       throw new Error("unsupported destination type");
   }
@@ -88,7 +106,7 @@ export const deliverToDestinations = async (
   const deliveryResults = await Promise.allSettled(
     input.destinations.map(
       async ({ destination, mappingId }) => {
-        console.log(`delivering to destination: ${JSON.stringify(destination)}`);
+        console.log(`delivering to ${destination.type} destination`);
         const deliverToDestinationInput: DeliverToDestinationInput = {
           destination,
           payload: input.payload,

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+
+const DestinationWebhookSchema = z.strictObject({
+  type: z.literal("webhook"),
+  url: z.string(),
+  verb: z.enum([
+    "PATCH",
+    "POST",
+    "PUT",
+  ]).default("POST"),
+  headers: z.record(
+    // `Content-Type` header override is not allowed
+    z.string().regex(/^(?!content-type).+$/i),
+    z.string()
+  ).optional(),
+});
+export const DestinationBucketSchema = z.strictObject({
+  type: z.literal("bucket"),
+  bucketName: z.string(),
+  path: z.string(),
+});
+
+export type DestinationBucket = z.infer<typeof DestinationBucketSchema>;
+
+export const DestinationSchema = z.strictObject({
+  mappingId: z.string().optional(),
+  destination: z.discriminatedUnion("type", [
+    DestinationWebhookSchema,
+    DestinationBucketSchema,
+  ]),
+});
+
+export type Destination = z.infer<typeof DestinationSchema>;

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -1,5 +1,7 @@
 import z from "zod";
 
+import { SftpConfigSchema } from "./RemoteConnectionConfig.js";
+
 const DestinationWebhookSchema = z.strictObject({
   type: z.literal("webhook"),
   url: z.string(),
@@ -14,10 +16,17 @@ const DestinationWebhookSchema = z.strictObject({
     z.string()
   ).optional(),
 });
+
 export const DestinationBucketSchema = z.strictObject({
   type: z.literal("bucket"),
   bucketName: z.string(),
   path: z.string(),
+});
+
+export const DestinationSftpSchema = z.strictObject({
+  type: z.literal("sftp"),
+  connectionDetails: SftpConfigSchema,
+  remotePath: z.string().default("/"),
 });
 
 export type DestinationBucket = z.infer<typeof DestinationBucketSchema>;
@@ -27,6 +36,7 @@ export const DestinationSchema = z.strictObject({
   destination: z.discriminatedUnion("type", [
     DestinationWebhookSchema,
     DestinationBucketSchema,
+    DestinationSftpSchema,
   ]),
 });
 

--- a/src/lib/types/PartnerRouting.ts
+++ b/src/lib/types/PartnerRouting.ts
@@ -1,5 +1,7 @@
 import z from "zod";
 
+import { DestinationSchema } from "./Destination.js";
+
 export const UsageIndicatorCodeSchema = z.enum([
   "P",
   "T",
@@ -7,39 +9,6 @@ export const UsageIndicatorCodeSchema = z.enum([
 ]);
 
 export type UsageIndicatorCode = z.infer<typeof UsageIndicatorCodeSchema>;
-
-const DestinationWebhookSchema = z.strictObject({
-  type: z.literal("webhook"),
-  url: z.string(),
-  verb: z.enum([
-    "PATCH",
-    "POST",
-    "PUT",
-  ]).default("POST"),
-  headers: z.record(
-    // `Content-Type` header override is not allowed
-    z.string().regex(/^(?!content-type).+$/i),
-    z.string()
-  ).optional(),
-});
-
-export const DestinationBucketSchema = z.strictObject({
-  type: z.literal("bucket"),
-  bucketName: z.string(),
-  path: z.string(),
-});
-
-export type DestinationBucket = z.infer<typeof DestinationBucketSchema>;
-
-const DestinationSchema = z.strictObject({
-  mappingId: z.string().optional(),
-  destination: z.discriminatedUnion("type", [
-    DestinationWebhookSchema,
-    DestinationBucketSchema,
-  ]),
-});
-
-export type Destination = z.infer<typeof DestinationSchema>;
 
 const BaseTransactionSetSchema = z.strictObject({
   description: z.string().optional(),

--- a/src/lib/types/RemoteConnectionConfig.ts
+++ b/src/lib/types/RemoteConnectionConfig.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { DestinationBucketSchema } from "./PartnerRouting";
+
+import { DestinationBucketSchema } from "./PartnerRouting.js";
 
 const FtpConfigSchema = z.strictObject({
   host: z.string(),

--- a/src/lib/types/RemoteConnectionConfig.ts
+++ b/src/lib/types/RemoteConnectionConfig.ts
@@ -13,7 +13,7 @@ const FtpConfigSchema = z.strictObject({
   }),
 });
 
-const SftpConfigSchema = z.strictObject({
+export const SftpConfigSchema = z.strictObject({
   host: z.string(),
   port: z.number().default(22),
   username: z.string(),

--- a/src/lib/types/RemoteConnectionConfig.ts
+++ b/src/lib/types/RemoteConnectionConfig.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { DestinationBucketSchema } from "./PartnerRouting.js";
+import { DestinationBucketSchema } from "./Destination.js";
 
 const FtpConfigSchema = z.strictObject({
   host: z.string(),


### PR DESCRIPTION
New destination config (password scrubbed):
![image](https://user-images.githubusercontent.com/39536918/219786075-71a91cc6-87ec-4879-903c-49c620ea482c.png)

Example output on delivery:
![image](https://user-images.githubusercontent.com/39536918/219785862-6d644d23-8a6a-4249-91bf-b198fc4a50dc.png)

Closes: #48 