### PR TITLE
feat: add support for `function` destination

### DIFF
--- a/src/lib/deliveryManager.ts
+++ b/src/lib/deliveryManager.ts
@@ -4,6 +4,7 @@ import { invokeMapping } from "./mappings.js";
 import { Destination } from "./types/Destination.js";
 import { ErrorWithContext } from "./errorWithContext.js";
 import * as bucket from "./destinations/bucket.js";
+import * as fn from "./destinations/function.js";
 import * as sftp from "./destinations/sftp.js";
 import * as webhook from "./destinations/webhook.js";
 
@@ -37,6 +38,7 @@ const deliveryFnForDestinationType: {
   ) => Promise<any>;
 } = {
   "bucket": bucket.deliverToDestination,
+  "function": fn.deliverToDestination,
   "sftp": sftp.deliverToDestination,
   "webhook": webhook.deliverToDestination,
 };

--- a/src/lib/deliveryManager.ts
+++ b/src/lib/deliveryManager.ts
@@ -28,7 +28,7 @@ export type ProcessDeliveriesInput = {
 
 export type DeliverToDestinationInput = {
   destination: Destination["destination"];
-  body: any;
+  destinationPayload: any;
   destinationFilename?: string;
 };
 
@@ -50,13 +50,10 @@ export const processSingleDelivery = async (
     ? await invokeMapping(input.mappingId, input.payload)
     : input.payload;
 
-  const body = typeof destinationPayload === "object"
-    ? JSON.stringify(destinationPayload)
-    : destinationPayload;
 
   const deliverToDestinationInput: DeliverToDestinationInput = {
     destination: input.destination,
-    body,
+    destinationPayload,
     destinationFilename: input.destinationFilename,
   };
 
@@ -127,4 +124,10 @@ export const generateDestinationFilename = (
   return extension
     ? `${baseFilename}.${extension}`
     : baseFilename;
+};
+
+export const payloadAsString = (destinationPayload: any): string => {
+  return typeof destinationPayload === "object"
+    ? JSON.stringify(destinationPayload)
+    : destinationPayload;
 };

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -1,7 +1,7 @@
 import { PutObjectCommand, PutObjectCommandInput } from "@stedi/sdk-client-buckets";
 
 import { bucketClient } from "../buckets.js";
-import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
 
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
@@ -16,7 +16,7 @@ export const deliverToDestination = async (
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,
-    body: input.body,
+    body: payloadAsString(input.destinationPayload),
   };
 
   await bucketClient().send(new PutObjectCommand(putCommandArgs));

--- a/src/lib/destinations/function.ts
+++ b/src/lib/destinations/function.ts
@@ -1,0 +1,12 @@
+import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { invokeFunction } from "../functions.js";
+
+export const deliverToDestination = async (
+  input: DeliverToDestinationInput
+): Promise<string | undefined> => {
+  if(input.destination.type !== "function") {
+    throw new Error("invalid destination type (must be function)");
+  }
+
+  return await invokeFunction(input.destination.functionName, input.body);
+};

--- a/src/lib/destinations/function.ts
+++ b/src/lib/destinations/function.ts
@@ -8,5 +8,8 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be function)");
   }
 
-  return await invokeFunction(input.destination.functionName, input.body);
+  return await invokeFunction(input.destination.functionName, {
+    additionalInput: input.destination.additionalInput,
+    payload: input.destinationPayload,
+  });
 };

--- a/src/lib/destinations/sftp.ts
+++ b/src/lib/destinations/sftp.ts
@@ -1,6 +1,6 @@
 import sftp from "ssh2-sftp-client";
 
-import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
 
 type SftpDeliveryResult = {
   host: string;
@@ -19,16 +19,17 @@ export const deliverToDestination = async (
   const filename = input.destinationFilename || `payload-${Date.now()}.out`;
   const remotePath = `${input.destination.remotePath}/${filename}`;
   const { host, username } = input.destination.connectionDetails;
+  const fileContents = payloadAsString(input.destinationPayload);
 
   const sftpClient = new sftp();
   await sftpClient.connect(input.destination.connectionDetails);
-  await sftpClient.put(Buffer.from(input.body), remotePath);
+  await sftpClient.put(Buffer.from(fileContents), remotePath);
   await sftpClient.end();
 
   return {
     host,
     username,
     remotePath,
-    contents: input.body,
+    contents: fileContents,
   };
 };

--- a/src/lib/destinations/webhook.ts
+++ b/src/lib/destinations/webhook.ts
@@ -1,7 +1,7 @@
 import fetch, { RequestInit } from "node-fetch";
 
 import { WebhookVerb } from "../types/Destination.js";
-import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
 
 type WebhookDeliveryResult = {
   method: WebhookVerb;
@@ -23,7 +23,7 @@ export const deliverToDestination = async (
       "Content-Type": "application/json",
       ...input.destination.headers,
     },
-    body: input.body,
+    body: payloadAsString(input.destinationPayload),
   };
 
   const response = await fetch(input.destination.url, params);

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -1,5 +1,3 @@
-import { TextEncoder } from "util";
-
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import {
   CreateFunctionCommand,
@@ -42,7 +40,7 @@ export const invokeFunction = async (
   const result = await functionClient().send(
     new InvokeFunctionCommand({
       functionName,
-      requestPayload: new TextEncoder().encode(JSON.stringify(input)),
+      requestPayload: Buffer.from(JSON.stringify(input)),
     })
   );
 
@@ -56,7 +54,7 @@ export const invokeFunctionAsync = async (
   input?: any
 ): Promise<FunctionInvocationId> => {
   const requestPayload = input
-    ? new TextEncoder().encode(JSON.stringify(input))
+    ? Buffer.from(JSON.stringify(input))
     : undefined;
 
   const { functionInvocationId } = await functionClient().send(

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -13,7 +13,7 @@ import {
   UpdateFunctionCommandOutput,
 } from "@stedi/sdk-client-functions";
 
-import { DEFAULT_SDK_CLIENT_PROPS } from "../lib/constants.js";
+import { DEFAULT_SDK_CLIENT_PROPS } from "./constants.js";
 
 type FunctionInvocationId = string;
 

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -38,7 +38,7 @@ export const functionClient = (): FunctionsClient => {
 export const invokeFunction = async (
   functionName: string,
   input: any
-): Promise<any> => {
+): Promise<string | undefined> => {
   const result = await functionClient().send(
     new InvokeFunctionCommand({
       functionName,

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -38,6 +38,7 @@ export const DestinationSftpSchema = z.strictObject({
 const DestinationFunctionSchema = z.strictObject({
   type: z.literal("function"),
   functionName: z.string(),
+  additionalInput: z.any().optional(),
 });
 
 export const DestinationSchema = z.strictObject({

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -35,12 +35,18 @@ export const DestinationSftpSchema = z.strictObject({
   remotePath: z.string().default("/"),
 });
 
+const DestinationFunctionSchema = z.strictObject({
+  type: z.literal("function"),
+  functionName: z.string(),
+});
+
 export const DestinationSchema = z.strictObject({
   mappingId: z.string().optional(),
   destination: z.discriminatedUnion("type", [
-    DestinationWebhookSchema,
     DestinationBucketSchema,
+    DestinationFunctionSchema,
     DestinationSftpSchema,
+    DestinationWebhookSchema,
   ]),
 });
 

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -37,9 +37,13 @@ void (async () => {
 
     let result: any;
     try {
-      result = JSON.parse(response);
+      // if response payload is present, try to parse as JSON
+      result = response
+        ? JSON.parse(response)
+        : undefined;
     } catch (e) {
-      result = response.toString();
+      // if response is not JSON, leave it as-is
+      result = response;
     }
 
     console.log("Result:");

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -1,4 +1,4 @@
-import { invokeFunction, invokeFunctionAsync } from "../support/functions.js";
+import { invokeFunction, invokeFunctionAsync } from "../lib/functions.js";
 
 // if input was provided, parse as object or string, otherwise return undefined
 const processFunctionInput = (input?: string) => {

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 
 import { compile, packForDeployment } from "../support/compile.js";
-import { createFunction, updateFunction } from "../support/functions.js";
+import { createFunction, updateFunction } from "../lib/functions.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
 
 dotenv.config({ override: true });

--- a/src/setup/destroy.ts
+++ b/src/setup/destroy.ts
@@ -12,7 +12,7 @@ import {
   DeleteKeyspaceCommand,
   GetValueCommand,
 } from "@stedi/sdk-client-stash";
-import { functionClient } from "../support/functions.js";
+import { functionClient } from "../lib/functions.js";
 import { DeleteFunctionCommand } from "@stedi/sdk-client-functions";
 import { BootstrapMetadataSchema } from "../lib/types/BootstrapMetadata.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";


### PR DESCRIPTION
I added a "hello-world" function destination, and tested with both JSON (`edi-inbound`) and string (`edi-outbound`) payloads, both with and without `additionalInput` for the function:

![image](https://user-images.githubusercontent.com/39536918/220776107-81dcdedf-77df-4c83-8668-93d367d74994.png)

example config (one entry with the optional `additionalInput` property and one without):

![image](https://user-images.githubusercontent.com/39536918/220776231-735c8102-b381-45a5-b336-189d50d62b10.png)

Closes #50 