### PR TITLE
feat: multi txns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .DS_Store
 .env
 coverage/
+.cache_ggshield

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
         "src/": "dist/"
       },
       "compile": "tsc"
+    },
+    "environmentVariables": {
+      "EXECUTIONS_BUCKET_NAME": "TEST-BUCKET"
     }
   }
 }

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -142,6 +142,7 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
               const guideSummary = await resolveGuide({
                 guideIdsForPartnership,
                 transactionSetType: transactionSetId,
+                release: functionalGroup.envelope?.release,
               });
 
               const transactionSetContents = fileContents.slice(

--- a/src/lib/archive/__tests__/archiveFile.unit.ts
+++ b/src/lib/archive/__tests__/archiveFile.unit.ts
@@ -2,6 +2,7 @@ import test from "ava";
 import { archiveFile } from "../archiveFile.js";
 import { reset, set } from "mockdate";
 import { mockBucketClient } from "../../testing/testHelpers.js";
+import { requiredEnvVar } from '../../environment.js';
 
 const buckets = mockBucketClient();
 
@@ -13,7 +14,7 @@ test("archives file using date specific folder structure, and timestamp suffix",
   await archiveFile({ currentKey: "foo", body: "bar" });
 
   t.like(buckets.calls()[0].args[0].input, {
-    bucketName: "ab33fa45-c67a-4653-bf5a-0bb85a90b332-executions",
+    bucketName: requiredEnvVar("EXECUTIONS_BUCKET_NAME"),
     key: "archive/2023/05/25/foo_2023-05-25T18:09:12.451Z",
   });
 });

--- a/src/lib/resolveGuide.ts
+++ b/src/lib/resolveGuide.ts
@@ -11,13 +11,15 @@ type GuideSummary = {
 type ResolveGuideInput = {
   guideIdsForPartnership: string[];
   transactionSetType: string;
+  release: string | undefined;
 };
 
 export const resolveGuide = async ({
   guideIdsForPartnership,
   transactionSetType,
+  release,
 }: ResolveGuideInput): Promise<GuideSummary> => {
-  const resolvedGuides: GuideSummary[] = [];
+  let resolvedGuides: GuideSummary[] = [];
   for await (const guideId of guideIdsForPartnership) {
     // deal with raw guide ids or not
     const guideIdsToAttemptToLoad =
@@ -42,6 +44,12 @@ export const resolveGuide = async ({
         break;
       }
     }
+  }
+
+  // if more than one matching guide is found, filter by release
+  // (maintains backwards compatibility, we only filter when we have multiple guides with same transaction set)
+  if (resolvedGuides.length > 1) {
+    resolvedGuides = resolvedGuides.filter((rg) => rg.release === release);
   }
 
   // if single matching guide is not found, throw an error

--- a/src/lib/types/OutboundEvent.ts
+++ b/src/lib/types/OutboundEvent.ts
@@ -5,6 +5,12 @@ export const OutboundEventSchema = z.strictObject({
     sendingPartnerId: z.string(),
     receivingPartnerId: z.string(),
     transactionSet: z.string().optional(),
+    release: z
+      .string()
+      .optional()
+      .describe(
+        "selects a guide with a specific release when multiple guides are configured for the same transaction set"
+      ),
   }),
   payload: z.any(),
 });

--- a/src/resources/X12/5010/850/outbound.json
+++ b/src/resources/X12/5010/850/outbound.json
@@ -2,8 +2,7 @@
   "metadata": {
     "sendingPartnerId": "this-is-me",
     "receivingPartnerId": "another-merchant",
-    "release": "optional-x12-release",
-    "transactionSet": "optional-x12-transaction-set"
+    "release": "005010"
   },
   "payload": {
     "heading": {

--- a/src/resources/X12/5010/850/outbound.json
+++ b/src/resources/X12/5010/850/outbound.json
@@ -1,7 +1,9 @@
 {
   "metadata": {
     "sendingPartnerId": "this-is-me",
-    "receivingPartnerId": "another-merchant"
+    "receivingPartnerId": "another-merchant",
+    "release": "optional-x12-release",
+    "transactionSet": "optional-x12-transaction-set"
   },
   "payload": {
     "heading": {


### PR DESCRIPTION
When reading EDI, if multiple guides exist for a given transaction set,
resolve the correct guide by matching the envelope release with the
guide release.

When writing EDI, allow user to specify a release. Bootstrap will select
the guide for writing based on the release if multiple guides for the
transaction set are found.

Safe to upgrade.

When reading EDI, If existing users have a guide which does not match
the release of the EDI they are receiving then it will continue to
select the same guide. Logic only changes when there are multiple guides
for the same transaction set, which would previously generate an error.

When writing EDI, users must pass in a new "release" parameter to select
a guide when there are multiple guides for the same transaction set. An
error is generated if a guide is not found with the specified release.
Existing users will not pass in this parameter and will be unaffected.

resolves #58 