### PR TITLE
feat: add test coverage to inbound function

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+STEDI_API_KEY=fake
+FTP_BUCKET_NAME=test-ftp-bucket
+EXECUTIONS_BUCKET_NAME=executions-bucket
+STEDI_FUNCTION_NAME=test-function

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,19 @@
+name: PR Test Suite
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          node-version: 16
+          cache: "npm"
+      - run: npm run test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,4 +16,5 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-      - run: npm run test
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -65,7 +65,13 @@
       "compile": "tsc"
     },
     "environmentVariables": {
-      "EXECUTIONS_BUCKET_NAME": "TEST-BUCKET"
+      "FTP_BUCKET_NAME": "test-ftp-bucket",
+      "EXECUTIONS_BUCKET_NAME": "executions-bucket",
+      "STEDI_FUNCTION_NAME": "test-function"
     }
+  },
+  "volta": {
+    "node": "16.19.1",
+    "npm": "9.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "enable-notifications": "ts-node-esm ./src/setup/enableBucketNotifications.ts",
     "execute": "ts-node-esm ./src/scripts/execute.ts",
     "migrate": "ts-node-esm ./src/setup/migrate.ts",
-    "test": "ava",
-    "coverage": "c8 ava"
+    "test": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_DEBUG=true ava",
+    "coverage": "DOTENV_CONFIG_PATH=.env.test c8 ava"
   },
   "author": "",
   "license": "ISC",
@@ -63,12 +63,6 @@
         "src/": "dist/"
       },
       "compile": "tsc"
-    },
-    "environmentVariables": {
-      "STEDI_API_KEY": "fake",
-      "FTP_BUCKET_NAME": "test-ftp-bucket",
-      "EXECUTIONS_BUCKET_NAME": "executions-bucket",
-      "STEDI_FUNCTION_NAME": "test-function"
     }
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "enable-notifications": "ts-node-esm ./src/setup/enableBucketNotifications.ts",
     "execute": "ts-node-esm ./src/scripts/execute.ts",
     "migrate": "ts-node-esm ./src/setup/migrate.ts",
-    "test": "DOTENV_CONFIG_PATH=.env.test DOTENV_CONFIG_DEBUG=true ava",
-    "coverage": "DOTENV_CONFIG_PATH=.env.test c8 ava"
+    "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/.bin/ava",
+    "coverage": "DOTENV_CONFIG_PATH=.env.test c8 node -r dotenv/config ./node_modules/.bin/ava"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
       "compile": "tsc"
     },
     "environmentVariables": {
+      "STEDI_API_KEY": "fake",
       "FTP_BUCKET_NAME": "test-ftp-bucket",
       "EXECUTIONS_BUCKET_NAME": "executions-bucket",
       "STEDI_FUNCTION_NAME": "test-function"

--- a/src/functions/edi/inbound/__fixtures__/events.ts
+++ b/src/functions/edi/inbound/__fixtures__/events.ts
@@ -1,0 +1,43 @@
+import { requiredEnvVar } from "../../../../lib/environment.js";
+
+export const sampleS3Event = (
+  key = "trading_partners/ANOTHERMERCH/inbound/inbound.edi"
+) => ({
+  Records: [
+    {
+      eventVersion: "2.2",
+      eventSource: "aws:s3",
+      awsRegion: "us-east-1",
+      eventTime: "2021-09-01T19:00:00.000Z",
+      eventName: "ObjectCreated:Put",
+      userIdentity: {
+        principalId: "",
+      },
+      requestParameters: {
+        sourceIPAddress: "",
+      },
+      responseElements: {
+        "x-amz-request-id": "",
+        "x-amz-id-2": "",
+      },
+      s3: {
+        s3SchemaVersion: "1.0",
+        configurationId: "",
+        bucket: {
+          name: requiredEnvVar("FTP_BUCKET_NAME"),
+          ownerIdentity: {
+            principalId: "",
+          },
+          arn: "",
+        },
+        object: {
+          key,
+          size: 1202,
+          eTag: "object eTag",
+
+          sequencer: "",
+        },
+      },
+    },
+  ],
+});

--- a/src/functions/edi/inbound/__tests__/handler.success-with-ack.ts
+++ b/src/functions/edi/inbound/__tests__/handler.success-with-ack.ts
@@ -86,7 +86,7 @@ test("translates, delivers & acks an incoming X12 file", async (t) => {
             destinations: [
               {
                 destination: {
-                  bucketName: "ab33fa45-c67a-4653-bf5a-0bb85a90b332-sftp",
+                  bucketName: "test-ftp-bucket",
                   path: "trading_partners/ANOTHERMERCH/outbound",
                   type: "bucket",
                 },

--- a/src/functions/edi/inbound/__tests__/handler.success-with-ack.ts
+++ b/src/functions/edi/inbound/__tests__/handler.success-with-ack.ts
@@ -1,0 +1,134 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import nock from "nock";
+import { sampleS3Event } from "../__fixtures__/events.js";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockGuideClient,
+  mockStashClient,
+  mockTranslateClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { GetObjectCommand, PutObjectCommand } from "@stedi/sdk-client-buckets";
+import { TranslateX12ToJsonCommand } from "@stedi/sdk-client-edi-translate";
+import { Readable } from "stream";
+import fs from "node:fs";
+import {
+  GetValueCommand,
+  IncrementValueCommand,
+} from "@stedi/sdk-client-stash";
+import { GetGuideCommand } from "@stedi/sdk-client-guides";
+
+const buckets = mockBucketClient();
+const translate = mockTranslateClient();
+const stash = mockStashClient();
+const guides = mockGuideClient();
+
+const sample855 = fs.readFileSync(
+  "./src/resources/X12/5010/855/inbound.edi",
+  "utf8"
+);
+
+test.before(() => {
+  nock.disableNetConnect();
+  mockExecutionTracking(buckets);
+});
+
+test.after.always(() => {
+  buckets.reset();
+  translate.reset();
+  stash.reset();
+});
+
+test("translates, delivers & acks an incoming X12 file", async (t) => {
+  // loading incoming EDI file from S3
+  buckets.on(GetObjectCommand, {}).resolves({
+    body: sdkStreamMixin(Readable.from([new TextEncoder().encode(sample855)])),
+  });
+
+  // mock translate response
+  translate.on(TranslateX12ToJsonCommand).resolvesOnce({
+    output: { transactionSets: [{}], envelope: { controlNumber: "123456" } },
+  });
+
+  stash
+    .on(GetValueCommand, { key: "lookup|ISA|14/ANOTHERMERCH" }) // mock sending partner lookup
+    .resolvesOnce({ value: { partnerId: "another-merchant" } })
+    .on(GetValueCommand, { key: "lookup|ISA|ZZ/THISISME" }) // mock receiving partner lookup
+    .resolvesOnce({ value: { partnerId: "this-is-me" } })
+    .on(GetValueCommand, { key: "partnership|another-merchant|this-is-me" }) // mock partnership lookup
+    .resolvesOnce({
+      value: {
+        transactionSets: [
+          {
+            acknowledgmentConfig: {
+              acknowledgmentType: "997",
+            },
+            description:
+              "Purchase Order Acknowledgements received from ANOTHERMERCH",
+            destinations: [
+              {
+                destination: {
+                  type: "webhook",
+                  url: "https://webhook.site/TESTING",
+                  verb: "POST",
+                },
+              },
+            ],
+            guideId: "01GRRSB3TXW9Z4J2J75Z9RPR3S",
+            receivingPartnerId: "this-is-me",
+            sendingPartnerId: "another-merchant",
+            usageIndicatorCode: "T",
+          },
+          {
+            description: "Outbound 997 Acknowledgments",
+            destinations: [
+              {
+                destination: {
+                  bucketName: "ab33fa45-c67a-4653-bf5a-0bb85a90b332-sftp",
+                  path: "trading_partners/ANOTHERMERCH/outbound",
+                  type: "bucket",
+                },
+              },
+            ],
+            transactionSetIdentifier: "997",
+            usageIndicatorCode: "T",
+          },
+        ],
+      },
+    })
+    .on(IncrementValueCommand, { key: "T|ISA|this-is-me|another-merchant" }) // 997 control number generation ISA
+    .resolves({ value: 9 })
+    .on(IncrementValueCommand, { key: "T|GS|this-is-me|another-merchant" }) // 997 control number generation GS
+    .resolves({ value: 9 });
+
+  // mock guide retrieval
+  guides.on(GetGuideCommand).resolvesOnce({
+    id: "LIVE_01GRRSB3TXW9Z4J2J75Z9RPR3S",
+    target: { standard: "x12", release: "005010", transactionSet: "855" },
+  });
+
+  // mock destination webhook delivery
+  const webhookRequest = nock("https://webhook.site")
+    .post("/TESTING", (body) =>
+      t.deepEqual(body, {
+        envelope: { controlNumber: "123456" },
+        transactionSets: [{}],
+      })
+    )
+    .reply(200, { thank: "you" });
+
+  const result = await handler(sampleS3Event());
+
+  t.assert(
+    webhookRequest.isDone(),
+    "delivered guide JSON to destination webhook"
+  );
+
+  t.deepEqual(result, {
+    filteredKeys: [],
+    processedKeys: ["trading_partners/ANOTHERMERCH/inbound/inbound.edi"],
+    processingErrors: [],
+  });
+});

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -74,6 +74,7 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
       const getObjectResponse = await bucketsClient.send(
         new GetObjectCommand(keyToProcess)
       );
+
       const fileContents = await consumers.text(
         getObjectResponse.body as Readable
       );
@@ -194,10 +195,12 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
             transactionSetConfigsForInterchange.find(
               (config) => "acknowledgmentConfig" in config
             );
+
           if (transactionSetConfigWithAck) {
             const ackTransactionSetConfig = getAckTransactionConfig(
               groupedTransactionSetConfigs.transactionSetConfigsWithoutGuideIds
             );
+
             // note: sendingPartnerId and receivingPartnerId are flip-flopped from interchange being ack'd
             const ackDeliveryInput: AckDeliveryInput = {
               ackTransactionSet: ackTransactionSetConfig,

--- a/src/lib/archive/__tests__/archiveFile.unit.ts
+++ b/src/lib/archive/__tests__/archiveFile.unit.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import { archiveFile } from "../archiveFile.js";
 import { reset, set } from "mockdate";
 import { mockBucketClient } from "../../testing/testHelpers.js";
-import { requiredEnvVar } from '../../environment.js';
+import { requiredEnvVar } from "../../environment.js";
 
 const buckets = mockBucketClient();
 
@@ -14,7 +14,7 @@ test("archives file using date specific folder structure, and timestamp suffix",
   await archiveFile({ currentKey: "foo", body: "bar" });
 
   t.like(buckets.calls()[0].args[0].input, {
-    bucketName: requiredEnvVar("EXECUTIONS_BUCKET_NAME"),
+    bucketName: "executions-bucket",
     key: "archive/2023/05/25/foo_2023-05-25T18:09:12.451Z",
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,4 @@
-import dotenv from "dotenv";
-
 import { requiredEnvVar } from "./environment.js";
-
-dotenv.config({ override: true });
 
 export const DEFAULT_SDK_CLIENT_PROPS = {
   apiKey: requiredEnvVar("STEDI_API_KEY"),

--- a/src/lib/destinations/webhook.ts
+++ b/src/lib/destinations/webhook.ts
@@ -1,7 +1,10 @@
 import fetch, { RequestInit } from "node-fetch";
 
 import { WebhookVerb } from "../types/Destination.js";
-import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
+import {
+  DeliverToDestinationInput,
+  payloadAsString,
+} from "../deliveryManager.js";
 
 type WebhookDeliveryResult = {
   method: WebhookVerb;
@@ -12,7 +15,7 @@ type WebhookDeliveryResult = {
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
 ): Promise<WebhookDeliveryResult> => {
-  if(input.destination.type !== "webhook") {
+  if (input.destination.type !== "webhook") {
     throw new Error("invalid destination type (must be webhook)");
   }
 
@@ -27,6 +30,7 @@ export const deliverToDestination = async (
   };
 
   const response = await fetch(input.destination.url, params);
+
   if (!response.ok) {
     throw new Error(
       `delivery to ${input.destination.url} failed: ${response.statusText} (status code: ${response.status})`

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -1,4 +1,8 @@
+import dotenv from "dotenv";
+
 export const requiredEnvVar = (key: string): string => {
+  dotenv.config({ override: true, path: process.env["DOTENV_CONFIG_PATH"] });
+
   const value = process.env[key];
 
   if (!value) {

--- a/src/lib/processEdi.ts
+++ b/src/lib/processEdi.ts
@@ -2,7 +2,7 @@ import { translateEdiToJson } from "./translateV3.js";
 
 export const processEdi = async (
   guideId: string,
-  ediDocument: string,
+  ediDocument: string
 ): Promise<any> => {
   const translation = await translateEdiToJson(ediDocument, guideId);
 

--- a/src/lib/resolveGuide.ts
+++ b/src/lib/resolveGuide.ts
@@ -1,5 +1,5 @@
 import { GetGuideCommand } from "@stedi/sdk-client-guides";
-import { guidesClient as buildGuideClient } from "../support/guide";
+import { guidesClient as buildGuideClient } from "../support/guide.js";
 
 const guidesClient = buildGuideClient();
 

--- a/src/lib/testing/testHelpers.ts
+++ b/src/lib/testing/testHelpers.ts
@@ -2,7 +2,10 @@ import {
   BucketsClient,
   DeleteObjectCommand,
   PutObjectCommand,
+  ReadBucketCommand,
 } from "@stedi/sdk-client-buckets";
+import { EDITranslateClient } from "@stedi/sdk-client-edi-translate";
+import { GuidesClient } from "@stedi/sdk-client-guides";
 import { StashClient } from "@stedi/sdk-client-stash";
 import { mockClient } from "aws-sdk-client-mock";
 import { translateClient } from "../translateV3.js";
@@ -24,10 +27,16 @@ export const mockBucketClient = () => {
 export const mockExecutionTracking = (mockedClient = mockBucketClient()) => {
   // mock bucket calls for execution tracking
   return mockedClient
-    .on(PutObjectCommand, { bucketName: executionsBucket })
-    .resolves({})
-    .on(DeleteObjectCommand, { bucketName: executionsBucket })
-    .resolves({});
+    .on(PutObjectCommand, { bucketName: executionsBucket }) // execution creation
+    .resolvesOnce({})
+    .on(DeleteObjectCommand, { bucketName: executionsBucket }) // execution cleanup
+    .resolvesOnce({})
+    .on(ReadBucketCommand, { bucketName: executionsBucket }) // infinite loop check
+    .resolvesOnce({
+      notifications: {
+        functions: [],
+      },
+    });
 };
 
 /**
@@ -39,6 +48,20 @@ export const mockStashClient = () => {
   return mockClient(StashClient);
 };
 
+/**
+ * Creates a mocked Stedi TranslateClient
+ *
+ * @returns a mocked TranslateClient
+ */
 export const mockTranslateClient = () => {
-  return mockClient(translateClient());
+  return mockClient(EDITranslateClient);
+};
+
+/**
+ * Creates a mocked Stedi GuidesClient
+ *
+ * @returns a mocked GuidesClient
+ */
+export const mockGuideClient = () => {
+  return mockClient(GuidesClient);
 };

--- a/src/setup/bootstrap.ts
+++ b/src/setup/bootstrap.ts
@@ -1,5 +1,3 @@
-import dotenv from "dotenv";
-dotenv.config({ override: true });
 import { ensureGuideExists } from "../support/guide.js";
 import { createSampleStashRecords } from "./bootstrap/createStashRecords.js";
 import { StashStorage } from "../lib/migration/stashStorage.js";

--- a/src/setup/bootstrap/createProfiles.ts
+++ b/src/setup/bootstrap/createProfiles.ts
@@ -1,5 +1,3 @@
-import dotenv from "dotenv";
-dotenv.config({ override: true });
 import { CreateX12ProfileCommand } from "@stedi/sdk-client-partners";
 import { partnersClient as buildPartnersClient } from "../../lib/partners.js";
 import { stashClient as buildStashClient } from "../../lib/stash.js";

--- a/src/setup/configureBuckets.ts
+++ b/src/setup/configureBuckets.ts
@@ -15,8 +15,6 @@ import { bucketClient } from "../lib/buckets.js";
 import { updateDotEnvFile } from "../support/utils.js";
 import { updateResourceMetadata } from "../support/bootstrapMetadata.js";
 
-dotenv.config({ override: true });
-
 (async () => {
   console.log("Configuring buckets...");
 

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -1,10 +1,7 @@
 import dotenv from "dotenv";
-
 import { compile, packForDeployment } from "../support/compile.js";
 import { createFunction, updateFunction } from "../lib/functions.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
-
-dotenv.config({ override: true });
 
 const createOrUpdateFunction = async (
   functionName: string,

--- a/src/setup/enableBucketNotifications.ts
+++ b/src/setup/enableBucketNotifications.ts
@@ -1,5 +1,3 @@
-import dotenv from "dotenv";
-
 import {
   ReadBucketCommand,
   UpdateBucketCommand,
@@ -9,8 +7,6 @@ import {
 import { bucketClient } from "../lib/buckets.js";
 import { requiredEnvVar } from "../lib/environment.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
-
-dotenv.config({ override: true });
 
 (async () => {
   const sftpBucketName = requiredEnvVar("SFTP_BUCKET_NAME");
@@ -32,17 +28,20 @@ dotenv.config({ override: true });
   const existingBucketConfig = await bucketClient().send(
     new ReadBucketCommand({
       bucketName: sftpBucketName,
-    }),
+    })
   );
 
   const currentNotificationFunctionCount =
     existingBucketConfig?.notifications?.functions?.length || 0;
 
   if (currentNotificationFunctionCount !== 0) {
-    const notificationFunctionNames = existingBucketConfig?.notifications?.functions?.map(
-      (fn) => fn.functionName
+    const notificationFunctionNames =
+      existingBucketConfig?.notifications?.functions?.map(
+        (fn) => fn.functionName
+      );
+    const bucketNotificationListOutput = JSON.stringify(
+      notificationFunctionNames
     );
-    const bucketNotificationListOutput = JSON.stringify(notificationFunctionNames);
     console.log(
       `Bucket notifications already enabled for ${sftpBucketName}: ${bucketNotificationListOutput}. Skipping.`
     );

--- a/src/setup/migrate.ts
+++ b/src/setup/migrate.ts
@@ -1,7 +1,4 @@
-import dotenv from "dotenv";
 import { migrator } from "../lib/migration/config.js";
-
-dotenv.config({ override: true });
 
 (async () => {
   console.log("Migrating Bootstrap...");


### PR DESCRIPTION
- Test covers the happy path for inbound processing, including ACKs.
- Adds Github Workflow for running test suite on PRs.
- Also improves how dotenv is used, by added a dedicated `.env.test` file that is passed to the ava runs via in package.json script. This helps keep any runtime config from `.env` from affecting test outputs.