### PR TITLE
feat: support Stedi preview env

### DIFF
--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -18,7 +18,7 @@ import {
   Convert,
   Record as BucketNotificationRecord,
 } from "../../../lib/types/BucketNotificationEvent.js";
-import { bucketClient } from "../../../lib/buckets.js";
+import { bucketsClient } from "../../../lib/clients/buckets.js";
 import {
   FilteredKey,
   GroupedEventKeys,
@@ -45,7 +45,7 @@ import { ErrorWithContext } from "../../../lib/errorWithContext.js";
 import { archiveFile } from "../../../lib/archive/archiveFile.js";
 
 // Buckets client is shared across handler and execution tracking logic
-const bucketsClient = bucketClient();
+const buckets = bucketsClient();
 
 export const handler = async (event: any): Promise<Record<string, any>> => {
   const executionId = generateExecutionId(event);
@@ -71,7 +71,7 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
     // Iterate through each key that represents an object within an `inbound` directory
     for await (const keyToProcess of groupedEventKeys.keysToProcess) {
       // load the object from the bucket
-      const getObjectResponse = await bucketsClient.send(
+      const getObjectResponse = await buckets.send(
         new GetObjectCommand(keyToProcess)
       );
 
@@ -219,7 +219,7 @@ export const handler = async (event: any): Promise<Record<string, any>> => {
         // ensure archival is complete
         await archivalRequest;
         // Delete the processed file (could also archive elsewhere if desired)
-        await bucketsClient.send(new DeleteObjectCommand(keyToProcess));
+        await buckets.send(new DeleteObjectCommand(keyToProcess));
         results.processedKeys.push(keyToProcess.key);
       } catch (e) {
         const error = ErrorWithContext.fromUnknown(e);

--- a/src/functions/ftp/external-poller/pollers/ftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/ftpPoller.ts
@@ -5,12 +5,14 @@ import { Client } from "basic-ftp";
 
 import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
-import { bucketClient } from "../../../../lib/buckets.js";
+import { bucketsClient } from "../../../../lib/clients/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
 import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 import { ErrorWithContext } from "../../../../lib/errorWithContext.js";
+
+const buckets = bucketsClient();
 
 export class FtpPoller extends RemotePoller {
   readonly client: Client;
@@ -46,7 +48,7 @@ export class FtpPoller extends RemotePoller {
     await this.client.downloadTo(localTmpFilePath, this.getFullFilePath(file));
 
     const destinationKey = `${destination.path}/${file.name}`;
-    await bucketClient().send(
+    await buckets.send(
       new PutObjectCommand({
         bucketName: destination.bucketName,
         key: destinationKey,

--- a/src/functions/ftp/external-poller/pollers/sftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/sftpPoller.ts
@@ -3,13 +3,14 @@ import sftp from "ssh2-sftp-client";
 
 import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
-import { bucketClient } from "../../../../lib/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
 import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 import { ErrorWithContext } from "../../../../lib/errorWithContext.js";
+import { bucketsClient } from "../../../../lib/clients/buckets.js";
 
+const buckets = bucketsClient();
 export class SftpPoller extends RemotePoller {
   readonly client: sftp;
 
@@ -33,7 +34,7 @@ export class SftpPoller extends RemotePoller {
     const fileContents = await this.client.get(this.getFullFilePath(file));
 
     const destinationKey = `${destination.path}/${file.name}`;
-    await bucketClient().send(
+    await buckets.send(
       new PutObjectCommand({
         bucketName: destination.bucketName,
         key: destinationKey,

--- a/src/lib/archive/archiveFile.ts
+++ b/src/lib/archive/archiveFile.ts
@@ -1,9 +1,9 @@
 import { PutObjectCommand } from "@stedi/sdk-client-buckets";
-import { bucketClient } from "../buckets.js";
+import { bucketsClient } from "../clients/buckets.js";
 import { requiredEnvVar } from "../environment.js";
 import { buildArchivalPath } from "./buildArchivalPath.js";
 
-const buckets = bucketClient();
+const buckets = bucketsClient();
 
 export const archiveFile = async ({
   currentKey,

--- a/src/lib/clients/as2.ts
+++ b/src/lib/clients/as2.ts
@@ -1,0 +1,19 @@
+import { As2Client, As2ClientConfig } from "@stedi/sdk-client-as2";
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+
+let _as2Client: As2Client;
+
+export const as2Client = () => {
+  if (_as2Client === undefined) {
+    const config: As2ClientConfig = {
+      ...DEFAULT_SDK_CLIENT_PROPS,
+    };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.stage = "preproduction";
+
+    _as2Client = new As2Client(config);
+  }
+
+  return _as2Client;
+};

--- a/src/lib/clients/buckets.ts
+++ b/src/lib/clients/buckets.ts
@@ -1,0 +1,21 @@
+import { BucketsClient, BucketsClientConfig } from "@stedi/sdk-client-buckets";
+
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+
+let _bucketClient: BucketsClient;
+
+export const bucketsClient = () => {
+  if (_bucketClient === undefined) {
+    const config: BucketsClientConfig = {
+      ...DEFAULT_SDK_CLIENT_PROPS,
+    };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.endpoint =
+        "https://buckets.cloud.us.preproduction.stedi.com/2022-05-05";
+
+    _bucketClient = new BucketsClient(config);
+  }
+
+  return _bucketClient;
+};

--- a/src/lib/clients/functions.ts
+++ b/src/lib/clients/functions.ts
@@ -1,0 +1,24 @@
+import {
+  FunctionsClient,
+  FunctionsClientConfig,
+} from "@stedi/sdk-client-functions";
+
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+
+let _functionsClient: FunctionsClient;
+
+export const functionsClient = (): FunctionsClient => {
+  if (_functionsClient === undefined) {
+    const config: FunctionsClientConfig = {
+      ...DEFAULT_SDK_CLIENT_PROPS,
+    };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.endpoint =
+        "https://functions.cloud.preproduction.stedi.com/2021-11-16";
+
+    _functionsClient = new FunctionsClient(config);
+  }
+
+  return _functionsClient;
+};

--- a/src/lib/clients/guides.ts
+++ b/src/lib/clients/guides.ts
@@ -1,0 +1,19 @@
+import { GuidesClient, GuidesClientConfig } from "@stedi/sdk-client-guides";
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+
+let _guidesClient: GuidesClient;
+
+export const guidesClient = () => {
+  if (_guidesClient === undefined) {
+    const config: GuidesClientConfig = {
+      ...DEFAULT_SDK_CLIENT_PROPS,
+    };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.endpoint = "https://guides.us.preproduction.stedi.com/2022-03-09";
+
+    _guidesClient = new GuidesClient(config);
+  }
+
+  return _guidesClient;
+};

--- a/src/lib/clients/partners.ts
+++ b/src/lib/clients/partners.ts
@@ -1,9 +1,8 @@
-import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import {
   PartnersClient,
   PartnersClientConfig,
 } from "@stedi/sdk-client-partners";
-import { DEFAULT_SDK_CLIENT_PROPS } from "./constants.js";
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
 
 let _partnersClient: PartnersClient;
 
@@ -11,11 +10,11 @@ export const partnersClient = () => {
   if (_partnersClient === undefined) {
     const config: PartnersClientConfig = {
       ...DEFAULT_SDK_CLIENT_PROPS,
-      maxAttempts: 5,
-      requestHandler: new NodeHttpHandler({
-        connectionTimeout: 5_000,
-      }),
     };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.endpoint =
+        "https://partners.us.preproduction.stedi.com/2022-01-01";
 
     _partnersClient = new PartnersClient(config);
   }

--- a/src/lib/clients/sftp.ts
+++ b/src/lib/clients/sftp.ts
@@ -1,0 +1,19 @@
+import { SftpClient, SftpClientConfig } from "@stedi/sdk-client-sftp";
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+
+let _sftpClient: SftpClient;
+
+export const sftpClient = () => {
+  if (_sftpClient === undefined) {
+    const config: SftpClientConfig = {
+      ...DEFAULT_SDK_CLIENT_PROPS,
+    };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.stage = "preproduction";
+
+    _sftpClient = new SftpClient(config);
+  }
+
+  return _sftpClient;
+};

--- a/src/lib/clients/stash.ts
+++ b/src/lib/clients/stash.ts
@@ -1,6 +1,5 @@
-import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import { StashClient, StashClientConfig } from "@stedi/sdk-client-stash";
-import { DEFAULT_SDK_CLIENT_PROPS } from "./constants.js";
+import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
 
 let _stashClient: StashClient;
 
@@ -8,11 +7,10 @@ export const stashClient = () => {
   if (_stashClient === undefined) {
     const config: StashClientConfig = {
       ...DEFAULT_SDK_CLIENT_PROPS,
-      maxAttempts: 5,
-      requestHandler: new NodeHttpHandler({
-        connectionTimeout: 5_000,
-      }),
     };
+
+    if (process.env["USE_PREVIEW"] !== undefined)
+      config.endpoint = "https://stash.us.preproduction.stedi.com/2022-04-20";
 
     _stashClient = new StashClient(config);
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,13 @@
+import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import { requiredEnvVar } from "./environment.js";
 
 export const DEFAULT_SDK_CLIENT_PROPS = {
   apiKey: requiredEnvVar("STEDI_API_KEY"),
   region: "us",
+  maxAttempts: 5,
+  requestHandler: new NodeHttpHandler({
+    connectionTimeout: 5_000,
+  }),
 };
 
 export const PARTNERS_KEYSPACE_NAME = "partners-configuration";

--- a/src/lib/destinations/as2.ts
+++ b/src/lib/destinations/as2.ts
@@ -1,11 +1,23 @@
-import { As2Client, StartFileTransferCommand, StartFileTransferCommandInput } from "@stedi/sdk-client-as2";
-import { PutObjectCommand, PutObjectCommandInput } from "@stedi/sdk-client-buckets";
+import {
+  As2Client,
+  StartFileTransferCommand,
+  StartFileTransferCommandInput,
+} from "@stedi/sdk-client-as2";
+import {
+  PutObjectCommand,
+  PutObjectCommandInput,
+} from "@stedi/sdk-client-buckets";
+import { as2Client } from "../clients/as2.js";
+import { bucketsClient } from "../clients/buckets.js";
 
-import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
-import { bucketClient } from "../buckets.js";
-import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
+import {
+  DeliverToDestinationInput,
+  payloadAsString,
+} from "../deliveryManager.js";
 
-const as2Client = new As2Client(DEFAULT_SDK_CLIENT_PROPS);
+const as2 = as2Client();
+const buckets = bucketsClient();
+
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
 ): Promise<StartFileTransferCommandInput> => {
@@ -23,14 +35,13 @@ export const deliverToDestination = async (
     body: payloadAsString(input.destinationPayload),
   };
 
-
   const startFileTransferCommandArgs: StartFileTransferCommandInput = {
     connectorId: input.destination.connectorId,
     sendFilePaths: [`/${input.destination.bucketName}/${key}`],
-  }
+  };
 
-  await bucketClient().send(new PutObjectCommand(putCommandArgs));
-  await as2Client.send(new StartFileTransferCommand(startFileTransferCommandArgs));
+  await buckets.send(new PutObjectCommand(putCommandArgs));
+  await as2.send(new StartFileTransferCommand(startFileTransferCommandArgs));
 
   return startFileTransferCommandArgs;
 };

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -1,12 +1,19 @@
-import { PutObjectCommand, PutObjectCommandInput } from "@stedi/sdk-client-buckets";
+import {
+  PutObjectCommand,
+  PutObjectCommandInput,
+} from "@stedi/sdk-client-buckets";
+import { bucketsClient } from "../clients/buckets.js";
+import {
+  DeliverToDestinationInput,
+  payloadAsString,
+} from "../deliveryManager.js";
 
-import { bucketClient } from "../buckets.js";
-import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
+const buckets = bucketsClient();
 
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
 ): Promise<PutObjectCommandInput> => {
-  if(input.destination.type !== "bucket") {
+  if (input.destination.type !== "bucket") {
     throw new Error("invalid destination type (must be bucket)");
   }
 
@@ -19,6 +26,6 @@ export const deliverToDestination = async (
     body: payloadAsString(input.destinationPayload),
   };
 
-  await bucketClient().send(new PutObjectCommand(putCommandArgs));
+  await buckets.send(new PutObjectCommand(putCommandArgs));
   return putCommandArgs;
 };

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -8,18 +8,22 @@ import {
   PutObjectCommand,
   ReadBucketCommand,
 } from "@stedi/sdk-client-buckets";
-
-import { bucketClient } from "./buckets.js";
 import { requiredEnvVar } from "./environment.js";
 import { ErrorWithContext } from "./errorWithContext.js";
+import { bucketsClient } from "./clients/buckets.js";
 
 const bucketName = requiredEnvVar("EXECUTIONS_BUCKET_NAME");
 
 let _executionsBucketClient: BucketsClient;
 let _infiniteLoopCheckPassed: boolean = false;
 
-export type FailureRecord = { bucketName?: string, key: string };
-export type FailureResponse = { statusCode: number, message: string, failureRecord: FailureRecord, error: ErrorObject }
+export type FailureRecord = { bucketName?: string; key: string };
+export type FailureResponse = {
+  statusCode: number;
+  message: string;
+  failureRecord: FailureRecord;
+  error: ErrorObject;
+};
 
 export const recordNewExecution = async (executionId: string, input: any) => {
   const client = await executionsBucketClient();
@@ -73,16 +77,17 @@ export const failedExecution = async (
   executionId: string,
   errorWithContext: ErrorWithContext
 ): Promise<FailureResponse> => {
-  const rawError = serializeError(errorWithContext)
+  const rawError = serializeError(errorWithContext);
   const failureRecord = await markExecutionAsFailed(executionId, rawError);
-  const statusCode = (errorWithContext as any)?.["$metadata"]?.httpStatusCode || 500;
+  const statusCode =
+    (errorWithContext as any)?.["$metadata"]?.httpStatusCode || 500;
   const message = "execution failed";
-  return { statusCode, message, failureRecord, error: rawError }
-}
+  return { statusCode, message, failureRecord, error: rawError };
+};
 
 const markExecutionAsFailed = async (
   executionId: string,
-  error: ErrorObject,
+  error: ErrorObject
 ): Promise<FailureRecord> => {
   const client = await executionsBucketClient();
   const key = `functions/${functionName()}/${executionId}/failure.json`;
@@ -100,26 +105,35 @@ const markExecutionAsFailed = async (
   return { bucketName, key };
 };
 
-export const generateExecutionId = (event: any) => hash({
-  functionName: functionName(),
-  event,
-});
+export const generateExecutionId = (event: any) =>
+  hash({
+    functionName: functionName(),
+    event,
+  });
 
 const functionName = () => requiredEnvVar("STEDI_FUNCTION_NAME");
 
 const executionsBucketClient = async (): Promise<BucketsClient> => {
-  if(_executionsBucketClient === undefined) {
-    _executionsBucketClient = bucketClient();
+  if (_executionsBucketClient === undefined) {
+    _executionsBucketClient = bucketsClient();
   }
 
   if (!_infiniteLoopCheckPassed) {
     // guard against infinite Function execution loops
-    const executionsBucket = await  _executionsBucketClient.send(new ReadBucketCommand({ bucketName }));
-    if (executionsBucket.notifications?.functions?.some((fn) => fn.functionName === functionName())) {
-      throw new Error("Error: executions bucket has recursive notifications configured")
+    const executionsBucket = await _executionsBucketClient.send(
+      new ReadBucketCommand({ bucketName })
+    );
+    if (
+      executionsBucket.notifications?.functions?.some(
+        (fn) => fn.functionName === functionName()
+      )
+    ) {
+      throw new Error(
+        "Error: executions bucket has recursive notifications configured"
+      );
     }
     _infiniteLoopCheckPassed = true;
   }
 
   return _executionsBucketClient;
-}
+};

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -1,43 +1,23 @@
-import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import {
   CreateFunctionCommand,
   CreateFunctionCommandOutput,
   DeleteFunctionCommand,
   DeleteFunctionCommandOutput,
-  FunctionsClient,
-  FunctionsClientConfig,
   InvokeFunctionCommand,
   UpdateFunctionCommand,
   UpdateFunctionCommandOutput,
 } from "@stedi/sdk-client-functions";
+import { functionsClient } from "./clients/functions.js";
 
-import { DEFAULT_SDK_CLIENT_PROPS } from "./constants.js";
+const functions = functionsClient();
 
 type FunctionInvocationId = string;
-
-let _functionsClient: FunctionsClient;
-
-export const functionClient = (): FunctionsClient => {
-  if (_functionsClient === undefined) {
-    const config: FunctionsClientConfig = {
-      ...DEFAULT_SDK_CLIENT_PROPS,
-      maxAttempts: 5,
-      requestHandler: new NodeHttpHandler({
-        connectionTimeout: 1_000,
-      }),
-    };
-
-    _functionsClient = new FunctionsClient(config);
-  }
-
-  return _functionsClient;
-};
 
 export const invokeFunction = async (
   functionName: string,
   input: any
 ): Promise<string | undefined> => {
-  const result = await functionClient().send(
+  const result = await functions.send(
     new InvokeFunctionCommand({
       functionName,
       requestPayload: Buffer.from(JSON.stringify(input)),
@@ -53,11 +33,9 @@ export const invokeFunctionAsync = async (
   functionName: string,
   input?: any
 ): Promise<FunctionInvocationId> => {
-  const requestPayload = input
-    ? Buffer.from(JSON.stringify(input))
-    : undefined;
+  const requestPayload = input ? Buffer.from(JSON.stringify(input)) : undefined;
 
-  const { functionInvocationId } = await functionClient().send(
+  const { functionInvocationId } = await functions.send(
     new InvokeFunctionCommand({
       functionName,
       invocationType: "Event",
@@ -77,7 +55,7 @@ export const createFunction = async (
     [key: string]: string;
   }
 ): Promise<CreateFunctionCommandOutput> => {
-  return functionClient().send(
+  return functions.send(
     new CreateFunctionCommand({
       functionName,
       package: functionPackage,
@@ -94,7 +72,7 @@ export const updateFunction = async (
     [key: string]: string;
   }
 ): Promise<UpdateFunctionCommandOutput> => {
-  return functionClient().send(
+  return functions.send(
     new UpdateFunctionCommand({
       functionName,
       package: functionPackage,
@@ -107,7 +85,7 @@ export const updateFunction = async (
 export const deleteFunction = async (
   functionName: string
 ): Promise<DeleteFunctionCommandOutput> => {
-  return functionClient().send(
+  return functions.send(
     new DeleteFunctionCommand({
       functionName,
     })

--- a/src/lib/loadPartnerProfile.ts
+++ b/src/lib/loadPartnerProfile.ts
@@ -3,14 +3,14 @@ import {
   GetX12ProfileCommandOutput,
 } from "@stedi/sdk-client-partners";
 import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { partnersClient } from "./clients/partners.js";
+import { stashClient } from "./clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
-import { partnersClient as buildPartnersClient } from "./partners.js";
-import { stashClient as buildStashClient } from "./stash.js";
+
 import { PartnerProfileSchema } from "./types/PartnerRouting.js";
 
-const stashClient = buildStashClient();
-
-const partnersClient = buildPartnersClient();
+const stash = stashClient();
+const partners = partnersClient();
 
 type Profile = Omit<
   GetX12ProfileCommandOutput,
@@ -22,7 +22,7 @@ export const loadPartnerProfile = async (
 ): Promise<Profile> => {
   if (process.env["USE_BETA"] === "true") {
     // load x12 Trading Partner Profile (pre-GA)
-    const profile = await partnersClient.send(
+    const profile = await partners.send(
       new GetX12ProfileCommand({
         id: partnerId,
       })
@@ -38,7 +38,7 @@ export const loadPartnerProfile = async (
     // load replica of x12 Trading Partner Profile from Stash
     const key = `profile|${partnerId}`;
 
-    const { value } = await stashClient.send(
+    const { value } = await stash.send(
       new GetValueCommand({
         keyspaceName: PARTNERS_KEYSPACE_NAME,
         key: `profile|${partnerId}`,

--- a/src/lib/loadPartnership.ts
+++ b/src/lib/loadPartnership.ts
@@ -1,9 +1,9 @@
 import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "./clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
-import { stashClient as buildStashClient } from "./stash.js";
 import { PartnershipSchema, Partnership } from "./types/PartnerRouting.js";
 
-const stashClient = buildStashClient();
+const stash = stashClient();
 
 export const loadPartnership = async (
   sendingPartnerId: string,
@@ -18,7 +18,7 @@ export const loadPartnership = async (
 
   for (const key of keysToCheck) {
     try {
-      const { value } = await stashClient.send(
+      const { value } = await stash.send(
         new GetValueCommand({
           keyspaceName: PARTNERS_KEYSPACE_NAME,
           key,

--- a/src/lib/migration/stashStorage.ts
+++ b/src/lib/migration/stashStorage.ts
@@ -1,9 +1,9 @@
 import { UmzugStorage } from "umzug";
 import { GetValueCommand, SetValueCommand } from "@stedi/sdk-client-stash";
 import { PARTNERS_KEYSPACE_NAME } from "../constants.js";
-import { stashClient as buildStashClient } from "../stash.js";
+import { stashClient } from "../clients/stash.js";
 
-const stashClient = buildStashClient();
+const stash = stashClient();
 
 export type StashStorageConstructorOptions = {
   /**
@@ -25,7 +25,7 @@ export class StashStorage implements UmzugStorage {
     const loggedMigrations = await this.executed();
     loggedMigrations.push(migrationName);
 
-    await stashClient.send(
+    await stash.send(
       new SetValueCommand({
         keyspaceName: this.keyspace,
         key: this.key,
@@ -44,7 +44,7 @@ export class StashStorage implements UmzugStorage {
       (name) => name !== migrationName
     );
 
-    await stashClient.send(
+    await stash.send(
       new SetValueCommand({
         keyspaceName: this.keyspace,
         key: this.key,
@@ -54,7 +54,7 @@ export class StashStorage implements UmzugStorage {
   }
 
   async executed(): Promise<string[]> {
-    const { value } = await stashClient.send(
+    const { value } = await stash.send(
       new GetValueCommand({
         keyspaceName: this.keyspace,
         key: this.key,

--- a/src/lib/resolveGuide.ts
+++ b/src/lib/resolveGuide.ts
@@ -1,7 +1,7 @@
 import { GetGuideCommand } from "@stedi/sdk-client-guides";
-import { guidesClient as buildGuideClient } from "../support/guide.js";
+import { guidesClient } from "./clients/guides.js";
 
-const guidesClient = buildGuideClient();
+const guides = guidesClient();
 
 type GuideSummary = {
   guideId: string;
@@ -28,7 +28,7 @@ export const resolveGuide = async ({
         : [guideId];
 
     for await (const guideIdToLoad of guideIdsToAttemptToLoad) {
-      const guide = await guidesClient.send(
+      const guide = await guides.send(
         new GetGuideCommand({ id: guideIdToLoad })
       );
 

--- a/src/lib/resolvePartnerIdFromISAId.ts
+++ b/src/lib/resolvePartnerIdFromISAId.ts
@@ -1,15 +1,15 @@
 import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "./clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
-import { stashClient as buildStashClient } from "./stash.js";
 import { ISAPartnerIdLookupSchema } from "./types/PartnerRouting.js";
 
-const stashClient = buildStashClient();
+const stash = stashClient();
 
 export const resolvePartnerIdFromISAId = async (
   isaId: string
 ): Promise<string> => {
   const key = `lookup|ISA|${isaId}`;
-  const { value } = await stashClient.send(
+  const { value } = await stash.send(
     new GetValueCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
       key,

--- a/src/lib/savePartnership.ts
+++ b/src/lib/savePartnership.ts
@@ -1,9 +1,9 @@
 import { SetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "./clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
-import { stashClient as buildStashClient } from "./stash.js";
 import { Partnership, PartnershipSchema } from "./types/PartnerRouting.js";
 
-const stashClient = buildStashClient();
+const stash = stashClient();
 
 export const savePartnership = async (
   id: string,
@@ -16,7 +16,7 @@ export const savePartnership = async (
     throw Error("Partnership does not match allowed schema");
   }
 
-  await stashClient.send(
+  await stash.send(
     new SetValueCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
       key: id,

--- a/src/migrations/001-single-guide-id-for-transaction-sets.ts
+++ b/src/migrations/001-single-guide-id-for-transaction-sets.ts
@@ -1,9 +1,9 @@
 import { ListValuesCommand } from "@stedi/sdk-client-stash";
-import { keys } from "object-hash";
+import { stashClient } from "../lib/clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "../lib/constants.js";
 import { savePartnership } from "../lib/savePartnership.js";
-import { stashClient as buildStashClient } from "../lib/stash.js";
-const stashClient = buildStashClient();
+
+const stash = stashClient();
 
 export const up = async () => {
   const partnerships = await loadPartnerships();
@@ -48,7 +48,7 @@ export const up = async () => {
 };
 
 const loadPartnerships = async (): Promise<any[]> => {
-  const { items } = await stashClient.send(
+  const { items } = await stash.send(
     new ListValuesCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
     })

--- a/src/setup/bootstrap/createProfiles.ts
+++ b/src/setup/bootstrap/createProfiles.ts
@@ -1,9 +1,10 @@
 import { CreateX12ProfileCommand } from "@stedi/sdk-client-partners";
-import { partnersClient as buildPartnersClient } from "../../lib/partners.js";
-import { stashClient as buildStashClient } from "../../lib/stash.js";
+
 import { PartnerProfileSchema } from "../../lib/types/PartnerRouting.js";
 import { SetValueCommand } from "@stedi/sdk-client-stash";
 import { PARTNERS_KEYSPACE_NAME } from "../../lib/constants.js";
+import { partnersClient } from "../../lib/clients/partners.js";
+import { stashClient } from "../../lib/clients/stash.js";
 
 export const createProfiles = async () => {
   const profiles = [
@@ -26,12 +27,12 @@ export const createProfiles = async () => {
   ];
 
   if (process.env["USE_BETA"] === "true") {
-    const partnersClient = buildPartnersClient();
+    const partners = partnersClient();
     console.log("[BETA] Creating X12 Trading Partner Profile in Partners API");
 
     for (const profile of profiles) {
       try {
-        await partnersClient.send(new CreateX12ProfileCommand(profile));
+        await partners.send(new CreateX12ProfileCommand(profile));
       } catch (error) {
         if (
           typeof error === "object" &&
@@ -45,7 +46,7 @@ export const createProfiles = async () => {
     }
   } else {
     console.log("Creating X12 Trading Partner Profile in Stash");
-    const stashClient = buildStashClient();
+    const stash = stashClient();
 
     for (const profile of profiles) {
       const parseResult = PartnerProfileSchema.safeParse(profile);
@@ -53,7 +54,7 @@ export const createProfiles = async () => {
       if (!parseResult.success) throw new Error(parseResult.error.message);
       // throw new Error(`Invalid profile for ${profile.id}`);
 
-      await stashClient.send(
+      await stash.send(
         new SetValueCommand({
           keyspaceName: PARTNERS_KEYSPACE_NAME,
           key: `profile|${profile.id}`,

--- a/src/setup/bootstrap/createStashRecords.ts
+++ b/src/setup/bootstrap/createStashRecords.ts
@@ -2,8 +2,9 @@ import { SetValueCommand } from "@stedi/sdk-client-stash";
 import { PARTNERS_KEYSPACE_NAME } from "../../lib/constants.js";
 import { requiredEnvVar } from "../../lib/environment.js";
 import { PartnershipInput } from "../../lib/types/PartnerRouting.js";
-import { stashClient as buildStashClient } from "../../lib/stash.js";
+
 import { savePartnership } from "../../lib/savePartnership.js";
+import { stashClient } from "../../lib/clients/stash.js";
 
 type CreateSampleStashRecordsInput = {
   guide850: string;
@@ -14,7 +15,7 @@ export const createSampleStashRecords = async ({
   guide850,
   guide855,
 }: CreateSampleStashRecordsInput) => {
-  const stashClient = buildStashClient();
+  const stash = stashClient();
 
   const sftpBucketName = requiredEnvVar("SFTP_BUCKET_NAME");
   const outboundBucketPath = "trading_partners/ANOTHERMERCH/outbound";
@@ -69,18 +70,18 @@ export const createSampleStashRecords = async ({
         destination: {
           bucketName: requiredEnvVar("SFTP_BUCKET_NAME"),
           path: "trading_partners/ANOTHERMERCH/outbound",
-          type: "bucket"
-        }
-      }
+          type: "bucket",
+        },
+      },
     ],
     transactionSetIdentifier: "997",
-    usageIndicatorCode: "T"
+    usageIndicatorCode: "T",
   });
 
   // write to Stash
   await savePartnership("partnership|this-is-me|another-merchant", partnership);
 
-  await stashClient.send(
+  await stash.send(
     new SetValueCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
       key: `lookup|ISA|14/ANOTHERMERCH`,
@@ -89,7 +90,7 @@ export const createSampleStashRecords = async ({
       },
     })
   );
-  await stashClient.send(
+  await stash.send(
     new SetValueCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
       key: `lookup|ISA|ZZ/THISISME`,

--- a/src/setup/bootstrap/ensureKeyspacesExist.ts
+++ b/src/setup/bootstrap/ensureKeyspacesExist.ts
@@ -3,20 +3,20 @@ import {
   GetKeyspaceCommand,
   GetKeyspaceCommandOutput,
 } from "@stedi/sdk-client-stash";
+import { stashClient } from "../../lib/clients/stash.js";
 import {
   PARTNERS_KEYSPACE_NAME,
   OUTBOUND_CONTROL_NUMBER_KEYSPACE_NAME,
   INBOUND_CONTROL_NUMBER_KEYSPACE_NAME,
 } from "../../lib/constants.js";
-import { stashClient as buildStashClient } from "../../lib/stash.js";
 
-const stashClient = buildStashClient();
+const stash = stashClient();
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const ensureKeyspace = async (keyspaceName: string) => {
   try {
-    await stashClient.send(
+    await stash.send(
       new CreateKeyspaceCommand({
         keyspaceName,
       })
@@ -48,7 +48,7 @@ const ensureKeyspace = async (keyspaceName: string) => {
   for (const keyspaceName of keyspaceNames) {
     let result: Partial<GetKeyspaceCommandOutput> = { status: "UNKNOWN" };
     for (let i = 0; i < 15; i++) {
-      result = await stashClient.send(new GetKeyspaceCommand({ keyspaceName }));
+      result = await stash.send(new GetKeyspaceCommand({ keyspaceName }));
 
       if (result.status === "ACTIVE") break;
 

--- a/src/setup/destroy.ts
+++ b/src/setup/destroy.ts
@@ -1,7 +1,5 @@
 import { DeleteBucketCommand } from "@stedi/sdk-client-buckets";
-import { bucketClient, emptyBucket } from "../lib/buckets.js";
-import { guidesClient } from "../support/guide.js";
-import { stashClient } from "../lib/stash.js";
+
 import { DeleteGuideCommand } from "@stedi/sdk-client-guides";
 import {
   PARTNERS_KEYSPACE_NAME,
@@ -12,16 +10,25 @@ import {
   DeleteKeyspaceCommand,
   GetValueCommand,
 } from "@stedi/sdk-client-stash";
-import { functionClient } from "../lib/functions.js";
 import { DeleteFunctionCommand } from "@stedi/sdk-client-functions";
 import { BootstrapMetadataSchema } from "../lib/types/BootstrapMetadata.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
+import { stashClient } from "../lib/clients/stash.js";
+import { bucketsClient } from "../lib/clients/buckets.js";
+import { guidesClient } from "../lib/clients/guides.js";
+import { functionsClient } from "../lib/clients/functions.js";
+import { emptyBucket } from "../lib/buckets.js";
+
+const stash = stashClient();
+const buckets = bucketsClient();
+const functions = functionsClient();
+const guides = guidesClient();
 
 (async () => {
   console.log("Deleting all resources provisioned by bootstrap");
 
   // get metadata from stash
-  const bootstrapMetadata = await stashClient().send(
+  const bootstrapMetadata = await stash.send(
     new GetValueCommand({
       keyspaceName: "partners-configuration",
       key: "bootstrap|metadata",
@@ -37,20 +44,16 @@ import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
   // Delete Guides
   console.log("Deleting Guides");
   for (const guideId of resources.GUIDE_IDS ?? []) {
-    await guidesClient().send(
-      new DeleteGuideCommand({ id: `LIVE_${guideId}` })
-    );
-    await guidesClient().send(
-      new DeleteGuideCommand({ id: `DRFT_${guideId}` })
-    );
+    await guides.send(new DeleteGuideCommand({ id: `LIVE_${guideId}` }));
+    await guides.send(new DeleteGuideCommand({ id: `DRFT_${guideId}` }));
   }
 
   // Delete Stash keyspaces
   console.log("Deleting Stash Keyspaces");
-  await stashClient().send(
+  await stash.send(
     new DeleteKeyspaceCommand({ keyspaceName: PARTNERS_KEYSPACE_NAME })
   );
-  await stashClient().send(
+  await stash.send(
     new DeleteKeyspaceCommand({
       keyspaceName: OUTBOUND_CONTROL_NUMBER_KEYSPACE_NAME,
     })
@@ -67,14 +70,13 @@ import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
   const functionPaths = getFunctionPaths();
   for (const path of functionPaths) {
     const functionName = functionNameFromPath(path);
-    await functionClient().send(new DeleteFunctionCommand({ functionName }));
+    await functions.send(new DeleteFunctionCommand({ functionName }));
   }
 
   console.log("Done");
 })();
 
 async function emptyAndDeleteBucket(bucketName: string) {
-  const client = await bucketClient();
   await emptyBucket(bucketName);
-  await client.send(new DeleteBucketCommand({ bucketName }));
+  await buckets.send(new DeleteBucketCommand({ bucketName }));
 }

--- a/src/setup/enableBucketNotifications.ts
+++ b/src/setup/enableBucketNotifications.ts
@@ -3,10 +3,12 @@ import {
   UpdateBucketCommand,
   UpdateBucketInput,
 } from "@stedi/sdk-client-buckets";
+import { bucketsClient } from "../lib/clients/buckets.js";
 
-import { bucketClient } from "../lib/buckets.js";
 import { requiredEnvVar } from "../lib/environment.js";
 import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
+
+const buckets = bucketsClient();
 
 (async () => {
   const sftpBucketName = requiredEnvVar("SFTP_BUCKET_NAME");
@@ -25,7 +27,7 @@ import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
 
   const functionName = functionNameFromPath(functionPaths[0]);
 
-  const existingBucketConfig = await bucketClient().send(
+  const existingBucketConfig = await buckets.send(
     new ReadBucketCommand({
       bucketName: sftpBucketName,
     })
@@ -55,9 +57,7 @@ import { functionNameFromPath, getFunctionPaths } from "../support/utils.js";
     },
   };
 
-  await bucketClient().send(
-    new UpdateBucketCommand(enableBucketNotificationsArgs)
-  );
+  await buckets.send(new UpdateBucketCommand(enableBucketNotificationsArgs));
 
   console.log(`\nDone.`);
   console.log(

--- a/src/support/bootstrapMetadata.ts
+++ b/src/support/bootstrapMetadata.ts
@@ -1,12 +1,14 @@
 import { GetValueCommand, SetValueCommand } from "@stedi/sdk-client-stash";
-import { stashClient } from "../lib/stash.js";
+import { stashClient } from "../lib/clients/stash.js";
 import {
   BootstrapMetadata,
   BootstrapMetadataSchema,
 } from "../lib/types/BootstrapMetadata.js";
 
+const stash = stashClient();
+
 export const getOrInitMetadata = async (): Promise<BootstrapMetadata> => {
-  const bootstrapMetadata = await stashClient().send(
+  const bootstrapMetadata = await stash.send(
     new GetValueCommand({
       keyspaceName: "partners-configuration",
       key: "bootstrap|metadata",
@@ -21,7 +23,7 @@ export const updateResourceMetadata = async (
   resources: BootstrapMetadata["resources"]
 ): Promise<void> => {
   const { resources: existingResources } = await getOrInitMetadata();
-  await stashClient().send(
+  await stash.send(
     new SetValueCommand({
       keyspaceName: "partners-configuration",
       key: "bootstrap|metadata",


### PR DESCRIPTION
Ground work for upcoming Engine support.

- Adds new `USE_PREVIEW` env var to toggle all clients to use preproduction.
- Refactors all Stedi clients to make them a little more consistent.
- There's some prettier changes for files my editor has mangled yet.