### PR TITLE
feat: make `destinationFilename` required property

### DIFF
--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -96,6 +96,7 @@ test("delivery via function invokes Stedi function with both payload and additio
       additionalInput,
     },
     payload,
+    destinationFilename: "unused",
   });
 
   t.deepEqual(functions.calls()[0].args[0].input, {
@@ -167,6 +168,7 @@ test("delivery via webhook sends payload to expected url", async (t) => {
       url,
     },
     payload,
+    destinationFilename: "unused",
   });
 
   t.assert(webhookRequest.isDone(), "delivered payload to destination webhook");

--- a/src/lib/deliveryManager.ts
+++ b/src/lib/deliveryManager.ts
@@ -18,19 +18,19 @@ export type ProcessSingleDeliveryInput = {
   destination: Destination["destination"];
   payload: object | string;
   mappingId?: string;
-  destinationFilename?: string;
+  destinationFilename: string;
 };
 
 export type ProcessDeliveriesInput = {
   destinations: Destination[];
   payload: object | string;
-  destinationFilename?: string;
+  destinationFilename: string;
 };
 
 export type DeliverToDestinationInput = {
   destination: Destination["destination"];
   destinationPayload: any;
-  destinationFilename?: string;
+  destinationFilename: string;
 };
 
 const deliveryFnForDestinationType: {

--- a/src/lib/destinations/as2.ts
+++ b/src/lib/destinations/as2.ts
@@ -1,5 +1,4 @@
 import {
-  As2Client,
   StartFileTransferCommand,
   StartFileTransferCommandInput,
 } from "@stedi/sdk-client-as2";
@@ -25,10 +24,7 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be as2)");
   }
 
-  const key = input.destinationFilename
-    ? `${input.destination.path}/${input.destinationFilename}`
-    : input.destination.path;
-
+  const key = `${input.destination.path}/${input.destinationFilename}`;
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -17,9 +17,7 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be bucket)");
   }
 
-  const key = input.destinationFilename
-    ? `${input.destination.path}/${input.destinationFilename}`
-    : input.destination.path;
+  const key = `${input.destination.path}/${input.destinationFilename}`;
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,

--- a/src/lib/destinations/sftp.ts
+++ b/src/lib/destinations/sftp.ts
@@ -1,6 +1,9 @@
 import sftp from "ssh2-sftp-client";
 
-import { DeliverToDestinationInput, payloadAsString } from "../deliveryManager.js";
+import {
+  DeliverToDestinationInput,
+  payloadAsString,
+} from "../deliveryManager.js";
 
 type SftpDeliveryResult = {
   host: string;
@@ -12,12 +15,11 @@ type SftpDeliveryResult = {
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
 ): Promise<SftpDeliveryResult> => {
-  if(input.destination.type !== "sftp") {
+  if (input.destination.type !== "sftp") {
     throw new Error("invalid destination type (must be sftp)");
   }
 
-  const filename = input.destinationFilename || `payload-${Date.now()}.out`;
-  const remotePath = `${input.destination.remotePath}/${filename}`;
+  const remotePath = `${input.destination.remotePath}/${input.destinationFilename}`;
   const { host, username } = input.destination.connectionDetails;
   const fileContents = payloadAsString(input.destinationPayload);
 


### PR DESCRIPTION
`destinationFilename` was optional, but in practice is always being sent by callers (as the destination type isn't considered by the caller, so it always includes a filename in case one is needed)