### PR TITLE
feat: add scheduled task to invoke edi-outbound workflow

### DIFF
--- a/.github/workflows/scheduled-write-edi.yaml
+++ b/.github/workflows/scheduled-write-edi.yaml
@@ -1,0 +1,56 @@
+name: Scheduled Write EDI Invocation
+
+on:
+  workflow_dispatch:
+    inputs:
+      loopCount:
+        description: 'Number of outbound EDI files to write (default=1)'
+        required: false
+        type: number
+  schedule:
+    # run every 15 mins (starting from 10 after each hour)
+    - cron: "10/15 * * * *"
+
+jobs:
+  run_batch_invocation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.7"
+      - run: npm ci
+        # run batch-invoke with loopCount=1 (will write one outbound document to sftp bucket)
+      - run: npm run write-edi 1
+        env:
+          STEDI_API_KEY: ${{secrets.WRITE_EDI_STEDI_API_KEY}}
+      # notify via slack if any failures are encountered
+      - if: ${{ failure() }}
+        name: "send failure alert via slack"
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":alert: Scheduled write edi invocation failed :alert:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|:point_right: Github Actions failure>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "configure-storage": "npm run ensure-keyspaces-exist && npm run configure-buckets",
     "ensure-keyspaces-exist": "ts-node-esm ./src/setup/bootstrap/ensureKeyspacesExist.ts",
     "enable-notifications": "ts-node-esm ./src/setup/enableBucketNotifications.ts",
+    "write-edi": "ts-node-esm ./src/scripts/writeEdi.ts",
     "execute": "ts-node-esm ./src/scripts/execute.ts",
     "migrate": "ts-node-esm ./src/setup/migrate.ts",
     "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/.bin/ava",


### PR DESCRIPTION
This replaces the previous scheduled task in the now-archived `write-edi-demo` repository:

- adds new `write-edi` npm script
- adds scheduled GH action to invoke `edi-outbound`  (new Stedi API key repository secret already added to support this)