### PR TITLE
feat: add configuration to send execution and file errors to destination

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "migrate": "ts-node-esm ./src/setup/migrate.ts",
     "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/.bin/ava",
     "coverage": "DOTENV_CONFIG_PATH=.env.test c8 node -r dotenv/config ./node_modules/.bin/ava",
-    "lint": "eslint src/**/*.ts --fix"
+    "lint": "npx eslint --fix \"src/**/*.ts\""
   },
   "author": "",
   "license": "ISC",

--- a/src/functions/edi/acknowledgment/__tests__/handler.ts
+++ b/src/functions/edi/acknowledgment/__tests__/handler.ts
@@ -68,7 +68,7 @@ test.serial(
     t.is(functions.commandCalls(InvokeFunctionCommand).length, 1);
     const { payload, metadata } = functions.commandCalls(
       InvokeFunctionCommand
-    )[0].args[0].input.payload as OutboundEvent;
+    )[0]!.args[0].input.payload as OutboundEvent;
     t.deepEqual(payload, {
       heading: {
         functional_group_response_header_AK1: {

--- a/src/functions/edi/inbound/__tests__/handler.delivery-failure-error.ts
+++ b/src/functions/edi/inbound/__tests__/handler.delivery-failure-error.ts
@@ -1,0 +1,105 @@
+import test from "ava";
+import nock from "nock";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockPartnersClient,
+  mockStashClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { handler } from "../handler.js";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { sampleTransactionProcessedEvent } from "../__fixtures__/events.js";
+import guideJSON855 from "../__fixtures__/855-guide.json" assert { type: "json" };
+import { GetObjectCommand } from "@stedi/sdk-client-buckets";
+import { Readable } from "node:stream";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+import { destinationExecutionErrorKey } from "../../../../lib/types/Destination.js";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
+
+const buckets = mockBucketClient();
+const partners = mockPartnersClient();
+const stash = mockStashClient();
+
+const partnershipId = "this-is-me_another-merchant";
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  buckets.reset();
+  partners.reset();
+  stash.reset();
+});
+
+test("sends execution errors to error destination when runtime error occurs", async (t) => {
+  // loading incoming EDI file from S3
+  buckets.on(GetObjectCommand, {}).resolves({
+    body: sdkStreamMixin(
+      Readable.from([new TextEncoder().encode(JSON.stringify(guideJSON855))])
+    ),
+  });
+
+  stash
+    .on(GetValueCommand, {
+      key: `destinations|${partnershipId}|855`,
+    }) // mock destinations lookup
+    .resolvesOnce({
+      value: {
+        description:
+          "Purchase Order Acknowledgements received from ANOTHERMERCH",
+        destinations: [
+          {
+            destination: {
+              type: "webhook",
+              url: "https://webhook.site/TESTING",
+              verb: "POST",
+            },
+          },
+        ],
+      },
+    });
+
+  stash
+    // loading destinations
+    .on(GetValueCommand, {
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: destinationExecutionErrorKey,
+    })
+    .resolvesOnce({
+      value: {
+        description: "execution errors",
+        destinations: [
+          {
+            destination: {
+              type: "webhook",
+              url: "https://example.com/error-webhook",
+            },
+          },
+        ],
+      },
+    });
+
+  // mock destination webhook delivery
+  const webhookRequest = nock("https://webhook.site")
+    .post("/TESTING", (body) => t.deepEqual(body, guideJSON855))
+    .reply(500);
+
+  const errorWebhook = nock("https://example.com")
+    .post("/error-webhook", (body: any) => {
+      return (
+        body.error.context.rejected[0].destination.destination.url ===
+          "https://webhook.site/TESTING" &&
+        body.error.context.rejected[0].payload &&
+        body.error.context.rejected[0].error
+      );
+    })
+    .reply(200);
+
+  const response = await handler(sampleTransactionProcessedEvent as any);
+
+  t.not(response.statusCode, 200, "not successful");
+  t.assert(webhookRequest.isDone(), "webhook request was made");
+  t.assert(errorWebhook.isDone(), "error webhook is called");
+});

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -14,7 +14,7 @@ import {
 } from "@stedi/sdk-client-buckets";
 import consumers from "stream/consumers";
 import { Readable } from "node:stream";
-import { loadDestinations } from "../../../lib/loadDestinations.js";
+import { loadTransactionDestinations } from "../../../lib/loadTransactionDestinations.js";
 import {
   generateDestinationFilename,
   processDeliveries,
@@ -50,7 +50,7 @@ export const handler = async (
     const guideJSON = JSON.parse(fileContents) as object;
 
     // get the destinations for this transaction set
-    const { destinations } = await loadDestinations({
+    const { destinations } = await loadTransactionDestinations({
       partnershipId: transactionEvent.detail.partnership.partnershipId,
       transactionSetIdentifier:
         transactionEvent.detail.transaction.transactionSetIdentifier,

--- a/src/functions/edi/outbound/__fixtures__/guideless-997.ts
+++ b/src/functions/edi/outbound/__fixtures__/guideless-997.ts
@@ -1,0 +1,25 @@
+export default {
+  metadata: {
+    partnershipId: "this-is-me_another-merchant",
+    usageIndicatorCode: "I",
+    useBuiltInGuide: true,
+  },
+  payload: {
+    heading: {
+      transaction_set_header_ST: {
+        transaction_set_identifier_code_01: "997",
+        transaction_set_control_number_02: 1,
+      },
+      functional_group_response_header_AK1: {
+        functional_identifier_code_01: "PO",
+        group_control_number_02: 1921,
+      },
+      functional_group_response_trailer_AK9: {
+        functional_group_acknowledge_code_01: "A",
+        number_of_transaction_sets_included_02: 1,
+        number_of_received_transaction_sets_03: 1,
+        number_of_accepted_transaction_sets_04: 1,
+      },
+    },
+  },
+};

--- a/src/functions/edi/outbound/__tests__/handler.guideless-997.ts
+++ b/src/functions/edi/outbound/__tests__/handler.guideless-997.ts
@@ -8,7 +8,7 @@ import {
   mockTranslateClient,
 } from "../../../../lib/testing/testHelpers.js";
 import { handler } from "../handler.js";
-import sampleOutboundEvent from "../../../../resources/X12/5010/997/outbound.json" assert { type: "json" };
+import sampleOutboundEvent from "../__fixtures__/guideless-997.js";
 import {
   GetX12PartnershipCommand,
   GetX12PartnershipOutput,

--- a/src/functions/events/file-error/__fixtures__/events.ts
+++ b/src/functions/events/file-error/__fixtures__/events.ts
@@ -1,0 +1,31 @@
+import { EngineFileError } from "../../../../lib/types/FileError";
+
+export const sampleFileErrorEvent: EngineFileError = {
+  "detail-type": "engine.file_error",
+  source: "stedi.engine",
+  detail: {
+    version: "2023-02-13",
+    direction: "RECEIVED",
+    fileId: "12345",
+    envelopes: {
+      interchange: {
+        acknowledgmentRequestedCode: "0",
+        controlNumber: 1746,
+        date: "220914",
+        receiverId: "THISISME ",
+        receiverQualifier: "ZZ",
+        senderId: "ANOTHERMERCH ",
+        senderQualifier: "14",
+        time: "2022",
+        usageIndicatorCode: "T",
+        versionNumberCode: "00501",
+      },
+    },
+    input: {
+      type: "EDI/X12",
+      bucketName: "stedi-default-engine-artifacts-217851219840",
+      key: "1f1b129a-9b86-04ea-3815-2d0f2b271c19/1746-1746-1.edi",
+    },
+    errors: ["An error occurred"],
+  },
+};

--- a/src/functions/events/file-error/__tests__/handler.ts
+++ b/src/functions/events/file-error/__tests__/handler.ts
@@ -1,0 +1,143 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import nock from "nock";
+import { sampleFileErrorEvent } from "../__fixtures__/events.js";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockFunctionsClient,
+  mockMappingsClient,
+  mockStashClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { GetValueCommand, SetValueCommand } from "@stedi/sdk-client-stash";
+import {
+  InvocationType,
+  InvokeFunctionCommand,
+} from "@stedi/sdk-client-functions";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+import {
+  destinationFileErrorEventsKey,
+  DestinationErrorEvents,
+} from "../../../../lib/types/Destination.js";
+import { MapDocumentCommand } from "@stedi/sdk-client-mappings";
+
+const stash = mockStashClient();
+const functions = mockFunctionsClient();
+const buckets = mockBucketClient();
+const mappings = mockMappingsClient();
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  stash.reset();
+  functions.reset();
+  buckets.reset();
+  mappings.reset();
+});
+
+test.serial(
+  `processes incoming engine.file_error event, sending event to configured destinations`,
+  async (t) => {
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: destinationFileErrorEventsKey,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        key: destinationFileErrorEventsKey,
+        value: {
+          description: "destinations to handle file events",
+          destinations: [
+            {
+              destination: {
+                type: "function",
+                functionName: "a-function",
+                additionalInput: "extra data",
+              },
+            },
+            {
+              destination: {
+                type: "stash",
+                keyspaceName: "a-keyspace",
+                keyPrefix: "a-prefix",
+              },
+            },
+            {
+              mappingId: "a-mapping",
+              destination: {
+                type: "webhook",
+                url: "https://example.com/a-webhook",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies DestinationErrorEvents,
+      });
+
+    functions
+      .on(InvokeFunctionCommand, {
+        functionName: "a-function",
+        invocationType: InvocationType.ASYNCHRONOUS,
+      })
+      .resolvesOnce({});
+
+    stash
+      .on(SetValueCommand, {
+        keyspaceName: "a-keyspace",
+      })
+      .resolvesOnce({});
+
+    mappings
+      .on(MapDocumentCommand, {
+        id: "a-mapping",
+      })
+      .resolvesOnce({ content: { mapped: true } });
+
+    const webhookRequest = nock("https://example.com")
+      .post("/a-webhook", (body: any) => {
+        if (body.mapped === true) {
+          return true;
+        }
+        return false;
+      })
+      .reply(200, { ok: true });
+
+    await handler(sampleFileErrorEvent);
+
+    t.is(functions.commandCalls(InvokeFunctionCommand).length, 1);
+    const { payload, additionalInput } = functions.commandCalls(
+      InvokeFunctionCommand
+    )[0]!.args[0].input.payload as {
+      payload: unknown;
+      additionalInput: unknown;
+    };
+    t.deepEqual(payload, sampleFileErrorEvent);
+    t.is(additionalInput, "extra data");
+
+    t.assert(webhookRequest.isDone());
+
+    t.is(
+      stash.commandCalls(SetValueCommand, {
+        keyspaceName: "a-keyspace",
+      }).length,
+      1
+    );
+    const { key, value } = stash.commandCalls(SetValueCommand, {
+      keyspaceName: "a-keyspace",
+    })[0]!.args[0].input;
+
+    t.assert(key?.includes("a-prefix"));
+    t.assert(key?.includes(sampleFileErrorEvent.detail.fileId));
+    t.deepEqual(value, sampleFileErrorEvent);
+
+    t.is(
+      mappings.commandCalls(MapDocumentCommand, {
+        id: "a-mapping",
+      }).length,
+      1
+    );
+  }
+);

--- a/src/functions/events/file-error/handler.ts
+++ b/src/functions/events/file-error/handler.ts
@@ -1,0 +1,41 @@
+import {
+  failedExecution,
+  generateExecutionId,
+  markExecutionAsSuccessful,
+  recordNewExecution,
+} from "../../../lib/execution.js";
+import { ErrorWithContext } from "../../../lib/errorWithContext.js";
+import { EngineFileError } from "../../../lib/types/FileError.js";
+import { loadFileErrorDestinations } from "../../../lib/loadFileErrorDestinations.js";
+
+import {
+  processDeliveries,
+  ProcessDeliveriesInput,
+} from "../../../lib/deliveryManager.js";
+
+export const handler = async (event: EngineFileError) => {
+  const executionId = generateExecutionId(event);
+  try {
+    await recordNewExecution(executionId, event);
+    await sendErrorToDestination(event);
+    await markExecutionAsSuccessful(executionId);
+
+    return {};
+  } catch (e) {
+    const error = ErrorWithContext.fromUnknown(e);
+    return failedExecution(executionId, error);
+  }
+};
+
+const sendErrorToDestination = async (event: EngineFileError) => {
+  console.log(event);
+  const errorDestinations = await loadFileErrorDestinations();
+
+  const processDeliveriesInput: ProcessDeliveriesInput = {
+    destinations: errorDestinations.destinations,
+    payload: event,
+    destinationFilename: `${event.detail.fileId}-${new Date().toUTCString()}`,
+  };
+
+  await processDeliveries(processDeliveriesInput);
+};

--- a/src/functions/ftp/external-poller/pollers/ftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/ftpPoller.ts
@@ -85,10 +85,10 @@ export class FtpPoller extends RemotePoller {
         break;
       }
 
-      listResult[0].isFile
+      listResult[0]!.isFile
         ? filesToProcess.push({
             path: remotePath,
-            ...this.extractFileDetails(listResult[0]),
+            ...this.extractFileDetails(listResult[0]!),
           })
         : // handle non-file as processing error since file was specifically requested
           processingErrors.push({

--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -48,13 +48,13 @@ test("delivery via as2 uploads file to bucket and starts as2 file transfer comma
     destinationFilename,
   });
 
-  t.deepEqual(buckets.calls()[0].args[0].input, {
+  t.deepEqual(buckets.calls()[0]!.args[0].input, {
     bucketName,
     key: `${path}/${destinationFilename}`,
     body: payload,
   });
 
-  t.deepEqual(as2Client.calls()[0].args[0].input, {
+  t.deepEqual(as2Client.calls()[0]!.args[0].input, {
     connectorId,
     sendFilePaths: [`/${bucketName}/${path}/${destinationFilename}`],
   });
@@ -76,7 +76,7 @@ test("delivery via bucket uploads file to bucket in specified path", async (t) =
     destinationFilename,
   });
 
-  t.deepEqual(buckets.calls()[0].args[0].input, {
+  t.deepEqual(buckets.calls()[0]!.args[0].input, {
     bucketName,
     key: `${path}/${destinationFilename}`,
     body: payload,
@@ -102,7 +102,7 @@ test("delivery via function invokes Stedi function with both payload and additio
     destinationFilename: "unused",
   });
 
-  t.deepEqual(functions.calls()[0].args[0].input, {
+  t.deepEqual(functions.calls()[0]!.args[0].input, {
     functionName,
     invocationType: InvocationType.SYNCHRONOUS,
     payload: {

--- a/src/lib/archive/__tests__/archiveFile.unit.ts
+++ b/src/lib/archive/__tests__/archiveFile.unit.ts
@@ -12,7 +12,7 @@ test.after(reset);
 test("archives file using date specific folder structure, and timestamp suffix", async (t) => {
   await archiveFile({ currentKey: "foo", body: "bar" });
 
-  t.like(buckets.calls()[0].args[0].input, {
+  t.like(buckets.calls()[0]!.args[0].input, {
     bucketName: "executions-bucket",
     key: "archive/2023/05/25/foo_2023-05-25T18:09:12.451Z",
   });

--- a/src/lib/archive/buildArchivalPath.ts
+++ b/src/lib/archive/buildArchivalPath.ts
@@ -4,20 +4,24 @@ export const buildArchivalPath = ({
   currentKey: string;
 }): string => {
   const timestamp = new Date().toISOString();
-  const [year, month, day] = timestamp.split(/[-T]/);
+  const [year, month, day] = timestamp.split(/[-T]/) as [
+    string,
+    string,
+    string
+  ];
 
   const currentKeyParts = currentKey.split("/");
   const currentFilenameParts = currentKeyParts.pop()!.split(".");
 
   let filename: string;
   if (currentFilenameParts.length > 1) {
-    const extension = currentFilenameParts.pop();
+    const extension = currentFilenameParts.pop()!;
     const filenameWithoutExtension = currentFilenameParts.join(".");
     filename = `${currentKeyParts.join(
       "/"
-    )}/${filenameWithoutExtension}_${timestamp}.${extension!}`;
+    )}/${filenameWithoutExtension}_${timestamp}.${extension}`;
   } else {
-    filename = `${currentFilenameParts[0]}_${timestamp}`;
+    filename = `${currentFilenameParts[0]!}_${timestamp}`;
   }
 
   return `archive/${year}/${month}/${day}/${filename}`;

--- a/src/lib/destinations/stash.ts
+++ b/src/lib/destinations/stash.ts
@@ -1,0 +1,39 @@
+import { SetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "../clients/stash.js";
+import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { DocumentType } from "@aws-sdk/types";
+import { ErrorWithContext } from "../errorWithContext.js";
+
+const stash = stashClient();
+
+export const deliverToDestination = async (
+  input: DeliverToDestinationInput
+): Promise<unknown> => {
+  if (input.destination.type !== "stash") {
+    throw new Error("invalid destination type (must be stash)");
+  }
+
+  const payloadSize =
+    typeof input.destinationPayload === "string"
+      ? input.destinationPayload.length
+      : JSON.stringify(input.destinationPayload).length;
+
+  if (payloadSize > 400_000) {
+    throw new ErrorWithContext(
+      "maximum payload size for stash destination exceeded. payload size must be less than 400KB",
+      {
+        payloadSize: `${Math.ceil(payloadSize / 1024)}KB`,
+      }
+    );
+  }
+
+  return await stash.send(
+    new SetValueCommand({
+      keyspaceName: input.destination.keyspaceName,
+      key: `${input.destination.keyPrefix ?? ""}${
+        input.destination.keyPrefix ? "/" : ""
+      }${input.destinationFilename}`,
+      value: input.destinationPayload as DocumentType,
+    })
+  );
+};

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -10,6 +10,11 @@ import {
 import { requiredEnvVar } from "./environment.js";
 import { ErrorWithContext } from "./errorWithContext.js";
 import { bucketsClient } from "./clients/buckets.js";
+import { loadExecutionErrorDestinations } from "./loadExecutionErrorDestinations.js";
+import {
+  processDeliveries,
+  ProcessDeliveriesInput,
+} from "./deliveryManager.js";
 
 const bucketName = requiredEnvVar("EXECUTIONS_BUCKET_NAME");
 
@@ -83,19 +88,36 @@ export const failedExecution = async (
 ): Promise<FailureResponse> => {
   const rawError = serializeError(errorWithContext);
   const failureRecord = await markExecutionAsFailed(executionId, rawError);
+
   const statusCode: number =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     ((errorWithContext as any)?.$metadata?.httpStatusCode as number) || 500;
   const message = "execution failed";
-  return { statusCode, message, failureRecord, error: rawError };
+  const failureResponse = {
+    statusCode,
+    message,
+    failureRecord,
+    error: rawError,
+  };
+  try {
+    await sendFailureToDestinations(failureResponse, executionId);
+  } catch (e) {
+    await markExecutionAsFailed(
+      executionId,
+      serializeError(e),
+      `failure-error-destination.json`
+    );
+  }
+  return failureResponse;
 };
 
 const markExecutionAsFailed = async (
   executionId: string,
-  error: ErrorObject
+  error: ErrorObject,
+  objectKey = "failure.json"
 ): Promise<FailureRecord> => {
   const client = executionsBucketClient();
-  const key = `functions/${functionName()}/${executionId}/failure.json`;
+  const key = `functions/${functionName()}/${executionId}/${objectKey}`;
   const result = await client.send(
     new PutObjectCommand({
       bucketName,
@@ -114,6 +136,22 @@ export const generateExecutionId = (event: unknown) =>
     functionName: functionName(),
     event,
   });
+
+// Used inside error path, do not throw
+export const sendFailureToDestinations = async (
+  failure: FailureResponse,
+  executionId: string
+): Promise<void> => {
+  const errorDestinations = await loadExecutionErrorDestinations();
+
+  const processDeliveriesInput: ProcessDeliveriesInput = {
+    destinations: errorDestinations.destinations,
+    payload: failure,
+    destinationFilename: `${executionId}-${new Date().toUTCString()}`,
+  };
+
+  await processDeliveries(processDeliveriesInput);
+};
 
 const functionName = () => requiredEnvVar("STEDI_FUNCTION_NAME");
 

--- a/src/lib/loadExecutionErrorDestinations.ts
+++ b/src/lib/loadExecutionErrorDestinations.ts
@@ -1,0 +1,38 @@
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "./clients/stash.js";
+import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
+import {
+  DestinationErrorEvents,
+  DestinationErrorEventsSchema,
+  destinationExecutionErrorKey,
+} from "./types/Destination.js";
+
+const stash = stashClient();
+
+export const loadExecutionErrorDestinations =
+  async (): Promise<DestinationErrorEvents> => {
+    try {
+      const { value } = await stash.send(
+        new GetValueCommand({
+          keyspaceName: PARTNERS_KEYSPACE_NAME,
+          key: destinationExecutionErrorKey,
+        })
+      );
+
+      if (!value) {
+        return { destinations: [] };
+      }
+
+      return DestinationErrorEventsSchema.parse(value);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "name" in error &&
+        error.name === "ResourceNotFoundException"
+      ) {
+        return { destinations: [] };
+      }
+      throw error;
+    }
+  };

--- a/src/lib/loadFileErrorDestinations.ts
+++ b/src/lib/loadFileErrorDestinations.ts
@@ -1,0 +1,38 @@
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "./clients/stash.js";
+import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
+import {
+  destinationFileErrorEventsKey,
+  DestinationErrorEvents,
+  DestinationErrorEventsSchema,
+} from "./types/Destination.js";
+
+const stash = stashClient();
+
+export const loadFileErrorDestinations =
+  async (): Promise<DestinationErrorEvents> => {
+    try {
+      const { value } = await stash.send(
+        new GetValueCommand({
+          keyspaceName: PARTNERS_KEYSPACE_NAME,
+          key: destinationFileErrorEventsKey,
+        })
+      );
+
+      if (!value) {
+        return { destinations: [] };
+      }
+
+      return DestinationErrorEventsSchema.parse(value);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "name" in error &&
+        error.name === "ResourceNotFoundException"
+      ) {
+        return { destinations: [] };
+      }
+      throw error;
+    }
+  };

--- a/src/lib/loadTransactionDestinations.ts
+++ b/src/lib/loadTransactionDestinations.ts
@@ -8,7 +8,7 @@ import {
 
 const stash = stashClient();
 
-export const loadDestinations = async ({
+export const loadTransactionDestinations = async ({
   partnershipId,
   transactionSetIdentifier,
 }: {
@@ -32,6 +32,7 @@ export const loadDestinations = async ({
       error.name === "ResourceNotFoundException"
     )
       return { destinations: [] };
-    else throw error;
+
+    throw error;
   }
 };

--- a/src/lib/testing/testHelpers.ts
+++ b/src/lib/testing/testHelpers.ts
@@ -10,6 +10,7 @@ import { GuidesClient } from "@stedi/sdk-client-guides";
 import { PartnersClient } from "@stedi/sdk-client-partners";
 import { StashClient } from "@stedi/sdk-client-stash";
 import { mockClient } from "aws-sdk-client-mock";
+import { MappingsClient } from "@stedi/sdk-client-mappings";
 
 const executionsBucket = process.env.EXECUTIONS_BUCKET_NAME ?? "";
 
@@ -87,4 +88,8 @@ export const mockGuideClient = () => {
 export const mockPartnersClient = () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
   return mockClient(PartnersClient as any);
+};
+
+export const mockMappingsClient = () => {
+  return mockClient(MappingsClient);
 };

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -49,6 +49,12 @@ const DestinationAs2Schema = DestinationBucketSchema.extend({
   connectorId: z.string(),
 });
 
+const DestinationStashSchema = z.strictObject({
+  type: z.literal("stash"),
+  keyspaceName: z.string(),
+  keyPrefix: z.string().optional(),
+});
+
 export const DestinationSchema = z.strictObject({
   mappingId: z.string().optional(),
   destination: z.discriminatedUnion("type", [
@@ -57,6 +63,7 @@ export const DestinationSchema = z.strictObject({
     DestinationFunctionSchema,
     DestinationSftpSchema,
     DestinationWebhookSchema,
+    DestinationStashSchema,
   ]),
 });
 
@@ -71,8 +78,35 @@ export type TransactionSetDestinations = z.infer<
   typeof TransactionSetDestinationsSchema
 >;
 
+export const destinationAckKey = (partnershipId: string) =>
+  `destinations|${partnershipId}|acknowledgements`;
+
 export const DestinationAckSchema = z.strictObject({
   generateFor: z.array(z.string().describe("Transaction Set ID")),
 });
 
 export type DestinationAck = z.infer<typeof DestinationAckSchema>;
+
+export const destinationExecutionErrorKey = "destinations|errors|execution";
+
+export const destinationFileErrorEventsKey = "destinations|errors|file_error";
+
+const DestinationErrorSchema = z.strictObject({
+  description: z.string().optional(),
+  mappingId: z.string().optional(),
+  destination: z.discriminatedUnion("type", [
+    DestinationFunctionSchema,
+    DestinationWebhookSchema,
+    DestinationStashSchema,
+    DestinationBucketSchema,
+  ]),
+});
+
+export const DestinationErrorEventsSchema = z.strictObject({
+  description: z.string().optional(),
+  destinations: z.array(DestinationErrorSchema),
+});
+
+export type DestinationErrorEvents = z.infer<
+  typeof DestinationErrorEventsSchema
+>;

--- a/src/lib/types/FileError.ts
+++ b/src/lib/types/FileError.ts
@@ -1,0 +1,25 @@
+import * as z from "zod";
+import { EventInterchangeSchema } from "./EventInterchange.js";
+
+export const EngineFileErrorSchema = z.object({
+  detail: z.object({
+    version: z.literal("2023-02-13"),
+    fileId: z.string(),
+    direction: z.enum(["SENT", "RECEIVED", "UNKNOWN"]),
+    envelopes: z
+      .object({
+        interchange: EventInterchangeSchema,
+      })
+      .optional(),
+    input: z.object({
+      type: z.string().describe(`"EDI/X12", "STEDI/GUIDE-JSON", or other`),
+      bucketName: z.string(),
+      key: z.string(),
+    }),
+    errors: z.array(z.unknown()),
+  }),
+  "detail-type": z.literal("engine.file_error"),
+  source: z.literal("stedi.engine"),
+});
+
+export type EngineFileError = z.infer<typeof EngineFileErrorSchema>;

--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -13,7 +13,7 @@ import { parseGuideId } from "../support/guide.js";
   const stash = stashClient();
   const guides = guidesClient();
 
-  if (existsSync(dirname) === false) {
+  if (!existsSync(dirname)) {
     console.error(`No directroy found at path '${dirname}'`);
     process.exit(1);
   }
@@ -28,12 +28,12 @@ import { parseGuideId } from "../support/guide.js";
   console.log("Restoring Guides...");
   const guideFiles = readdirSync(`${dirname}/guides`);
   for (const guideFile of guideFiles) {
-    const [oldGuidId] = guideFile.split(".");
+    const [oldGuidId] = guideFile.split(".") as [string];
     const guideRaw = readFileSync(`${dirname}/guides/${guideFile}`, "utf-8");
     const guideBody = JSON.parse(guideRaw);
 
     try {
-      const guide = await guides.send(new CreateGuideCommand(guideBody as any));
+      const guide = await guides.send(new CreateGuideCommand(guideBody));
 
       stashRaw = stashRaw.replace(oldGuidId, parseGuideId(guide.id!));
     } catch (error) {

--- a/src/scripts/writeEdi.ts
+++ b/src/scripts/writeEdi.ts
@@ -10,7 +10,8 @@ const DEFAULT_850_PAYLOAD = JSON.parse(
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   const functionName = "edi-outbound";
-  const loopCount: number = parseInt(process.argv[2]) || DEFAULT_LOOP_COUNT;
+  const loopCount: number =
+    (process.argv[2] && parseInt(process.argv[2], 10)) || DEFAULT_LOOP_COUNT;
   console.log(
     `Invoking ${functionName} function with loop count: ${loopCount}\n`
   );

--- a/src/setup/configureBuckets.ts
+++ b/src/setup/configureBuckets.ts
@@ -47,7 +47,7 @@ import { sftpClient } from "../lib/clients/sftp.js";
   }
 
   // Use a separate bucket for tracking function executions
-  const stediAccountId = user.bucketName.split("-sftp")[0];
+  const stediAccountId = user.bucketName.split("-sftp")[0]!;
   const executionsBucketName = `${stediAccountId}-executions`;
 
   const bucketsList = await buckets.send(new ListBucketsCommand({}));

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -138,6 +138,23 @@ const createOrUpdateEventBinding = async (
     )
   );
 
+  void createOrUpdateEventBinding(
+    "events-file-error",
+    {
+      source: ["stedi.engine"],
+      "detail-type": ["engine.file_error"],
+    },
+    "engine-file-errors"
+  );
+  EVENT_BINDING_NAMES.push("engine-file-errors");
+
+  promises.push(
+    waitUntilEventToFunctionBindingCreateComplete(
+      { client: events, maxWaitTime },
+      { eventToFunctionBindingName: "engine-file-errors" }
+    )
+  );
+
   console.log("Waiting for event binding deploys to complete");
   await promises;
 

--- a/src/setup/destroy.ts
+++ b/src/setup/destroy.ts
@@ -170,7 +170,7 @@ const partners = partnersClient();
   console.log("Done");
 })();
 
-async function emptyAndDeleteBucket(bucketName: string) {
+async function _emptyAndDeleteBucket(bucketName: string) {
   await emptyBucket(bucketName);
   await buckets.send(new DeleteBucketCommand({ bucketName }));
 }

--- a/src/support/guide.ts
+++ b/src/support/guide.ts
@@ -17,7 +17,7 @@ import { guidesClient } from "../lib/clients/guides.js";
 const guides = guidesClient();
 
 export const parseGuideId = (fullGuideId: string): string =>
-  fullGuideId.includes("_") ? fullGuideId.split("_")[1] : fullGuideId;
+  fullGuideId.includes("_") ? fullGuideId.split("_")[1]! : fullGuideId;
 
 export const ensureGuideExists = async (
   guidePath: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": ["es2020"],
-    "module": "esnext",                                /* Specify what module code is generated. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "module": "esnext" /* Specify what module code is generated. */,
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
 
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "noUncheckedIndexedAccess": true,
     "sourceMap": true,
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
 
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  
+
   "ts-node": {
     "esm": true
   },


### PR DESCRIPTION
Execution failures occurring in bootstrap, such as destination failures, can now be forwarded to a function, webhook, bucket, or stash. When the error is from a destination failure it will contain information needed to re-drive the payload to the destination.

Bind File error events from engine by default to a function. File error events can be forwarded to a function, webhook, bucket, or stash.