### PR TITLE
feat: use un-opinionated payload when invoking destination Stedi functions

### DIFF
--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -27,131 +27,198 @@ test.afterEach.always(() => {
   sinon.reset();
 });
 
-test("delivery via as2 uploads file to bucket and starts as2 file transfer command", async (t) => {
-  const bucketName = "test-as2-bucket";
-  const path = "my-as2-trading-partner/outbound";
-  const destinationFilename = "850-0001.edi";
-  const connectorId = "my-as2-connector-id";
-  const payload = "file-contents";
+test.serial(
+  "delivery via as2 uploads file to bucket and starts as2 file transfer command",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "my-as2-trading-partner/outbound";
+    const destinationFilename = "850-0001.edi";
+    const connectorId = "my-as2-connector-id";
+    const payload = "file-contents";
 
-  await processSingleDelivery({
-    destination: {
-      type: "as2",
+    await processSingleDelivery({
+      destination: {
+        type: "as2",
+        bucketName,
+        path,
+        connectorId,
+      },
+      payload: "file-contents",
+      destinationFilename,
+    });
+
+    t.deepEqual(buckets.calls()[0].args[0].input, {
       bucketName,
-      path,
+      key: `${path}/${destinationFilename}`,
+      body: payload,
+    });
+
+    t.deepEqual(as2Client.calls()[0].args[0].input, {
       connectorId,
-    },
-    payload: "file-contents",
-    destinationFilename,
-  });
+      sendFilePaths: [`/${bucketName}/${path}/${destinationFilename}`],
+    });
+  }
+);
 
-  t.deepEqual(buckets.calls()[0].args[0].input, {
-    bucketName,
-    key: `${path}/${destinationFilename}`,
-    body: payload,
-  });
+test.serial(
+  "delivery via bucket uploads file to bucket in specified path",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "my-as2-trading-partner/outbound";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
 
-  t.deepEqual(as2Client.calls()[0].args[0].input, {
-    connectorId,
-    sendFilePaths: [`/${bucketName}/${path}/${destinationFilename}`],
-  });
-});
+    await processSingleDelivery({
+      destination: {
+        type: "bucket",
+        bucketName,
+        path,
+      },
+      payload,
+      destinationFilename,
+    });
 
-test("delivery via bucket uploads file to bucket in specified path", async (t) => {
-  const bucketName = "test-as2-bucket";
-  const path = "my-as2-trading-partner/outbound";
-  const destinationFilename = "850-0001.edi";
-  const payload = "file-contents";
-
-  await processSingleDelivery({
-    destination: {
-      type: "bucket",
+    t.deepEqual(buckets.calls()[0].args[0].input, {
       bucketName,
-      path,
-    },
-    payload,
-    destinationFilename,
-  });
+      key: `${path}/${destinationFilename}`,
+      body: payload,
+    });
+  }
+);
 
-  t.deepEqual(buckets.calls()[0].args[0].input, {
-    bucketName,
-    key: `${path}/${destinationFilename}`,
-    body: payload,
-  });
-});
+test.serial(
+  "delivery via function fails when payload is string but additionalInput object is configured",
+  async (t) => {
+    const functionName = "test-function";
+    const payload = "file-contents";
+    const additionalInput = {
+      extraKey: "extra-value",
+    };
 
-test("delivery via function invokes Stedi function with both payload and additionalInput", async (t) => {
-  const functionName = "test-function";
-  const payload = "file-contents";
-  const additionalInput = {
-    extraKey: "extra-value",
-  };
+    await t.throwsAsync(
+      async () =>
+        await processSingleDelivery({
+          destination: {
+            type: "function",
+            functionName,
+            additionalInput,
+          },
+          payload,
+          destinationFilename: "unused",
+        }),
+      {
+        instanceOf: Error,
+        message:
+          "additionalInput for function destination not supported with string payload",
+      }
+    );
+  }
+);
 
-  functions.on(InvokeFunctionCommand, { functionName }).resolvesOnce({});
+test.serial(
+  "delivery via function invokes Stedi function with payload with no additionalInput",
+  async (t) => {
+    const functionName = "test-function";
+    const payload = { key: "value" };
 
-  await processSingleDelivery({
-    destination: {
-      type: "function",
+    functions.on(InvokeFunctionCommand, { functionName }).resolvesOnce({});
+
+    await processSingleDelivery({
+      destination: {
+        type: "function",
+        functionName,
+      },
+      payload,
+      destinationFilename: "unused",
+    });
+
+    t.deepEqual(functions.calls()[0].args[0].input, {
       functionName,
-      additionalInput,
-    },
-    payload,
-    destinationFilename: "unused",
-  });
+      requestPayload: Buffer.from(
+        JSON.stringify({
+          ...payload,
+        })
+      ),
+    });
+  }
+);
 
-  t.deepEqual(functions.calls()[0].args[0].input, {
-    functionName,
-    requestPayload: Buffer.from(
-      JSON.stringify({
+test.serial(
+  "delivery via function invokes Stedi function with both payload and additionalInput",
+  async (t) => {
+    const functionName = "test-function";
+    const payload = { key: "value" };
+    const additionalInput = { extraKey: "extra-value" };
+
+    functions.on(InvokeFunctionCommand, { functionName }).resolvesOnce({});
+
+    await processSingleDelivery({
+      destination: {
+        type: "function",
+        functionName,
         additionalInput,
-        payload,
-      })
-    ),
-  });
-});
+      },
+      payload,
+      destinationFilename: "unused",
+    });
 
-test("delivery via sftp uploads to remote sftp at expected path", async (t) => {
-  const host = "test-host.sftp.com";
-  const port = 22;
-  const username = "test-user";
-  const password = "test-password";
-  const remotePath = "/outbound";
-  const destinationFilename = "850-0001.edi";
-  const payload = "file-contents";
+    t.deepEqual(functions.calls()[0].args[0].input, {
+      functionName,
+      requestPayload: Buffer.from(
+        JSON.stringify({
+          ...payload,
+          ...additionalInput,
+        })
+      ),
+    });
+  }
+);
 
-  await processSingleDelivery({
-    destination: {
-      type: "sftp",
-      connectionDetails: {
+test.serial(
+  "delivery via sftp uploads to remote sftp at expected path",
+  async (t) => {
+    const host = "test-host.sftp.com";
+    const port = 22;
+    const username = "test-user";
+    const password = "test-password";
+    const remotePath = "/outbound";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "sftp",
+        connectionDetails: {
+          host,
+          port,
+          username,
+          password,
+        },
+        remotePath,
+      },
+      destinationFilename,
+      payload,
+    });
+
+    t.assert(
+      sftpStub.connect.calledOnceWith({
         host,
         port,
         username,
         password,
-      },
-      remotePath,
-    },
-    destinationFilename,
-    payload,
-  });
+      })
+    );
+    t.assert(
+      sftpStub.put.calledOnceWith(
+        Buffer.from(payload),
+        `${remotePath}/${destinationFilename}`
+      )
+    );
+    t.assert(sftpStub.end.calledOnceWith());
+  }
+);
 
-  t.assert(
-    sftpStub.connect.calledOnceWith({
-      host,
-      port,
-      username,
-      password,
-    })
-  );
-  t.assert(
-    sftpStub.put.calledOnceWith(
-      Buffer.from(payload),
-      `${remotePath}/${destinationFilename}`
-    )
-  );
-  t.assert(sftpStub.end.calledOnceWith());
-});
-
-test("delivery via webhook sends payload to expected url", async (t) => {
+test.serial("delivery via webhook sends payload to expected url", async (t) => {
   const payload = "file-contents";
   const baseUrl = "https://webhook.site";
   const endpoint = "/test-endpoint";

--- a/src/lib/destinations/function.ts
+++ b/src/lib/destinations/function.ts
@@ -1,15 +1,32 @@
 import { DeliverToDestinationInput } from "../deliveryManager.js";
 import { invokeFunction } from "../functions.js";
+import { DestinationFunction } from "../types/Destination.js";
 
 export const deliverToDestination = async (
   input: DeliverToDestinationInput
 ): Promise<string | undefined> => {
-  if(input.destination.type !== "function") {
+  if (input.destination.type !== "function") {
     throw new Error("invalid destination type (must be function)");
   }
 
-  return await invokeFunction(input.destination.functionName, {
-    additionalInput: input.destination.additionalInput,
-    payload: input.destinationPayload,
-  });
+  const functionInput = buildFunctionInput(
+    input.destinationPayload,
+    input.destination.additionalInput
+  );
+  return await invokeFunction(input.destination.functionName, functionInput);
+};
+
+const buildFunctionInput = (
+  destinationPayload: DeliverToDestinationInput["destinationPayload"],
+  additionalInput?: DestinationFunction["additionalInput"]
+): string | unknown => {
+  if (additionalInput && typeof destinationPayload === "string") {
+    throw new Error(
+      "additionalInput for function destination not supported with string payload"
+    );
+  }
+
+  return typeof destinationPayload === "object"
+    ? { ...destinationPayload, ...additionalInput }
+    : destinationPayload;
 };

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -44,6 +44,8 @@ const DestinationFunctionSchema = z.strictObject({
   additionalInput: z.any().optional(),
 });
 
+export type DestinationFunction = z.infer<typeof DestinationFunctionSchema>;
+
 const DestinationAs2Schema = DestinationBucketSchema.extend({
   type: z.literal("as2"),
   connectorId: z.string(),


### PR DESCRIPTION
**Previous behavior:**

When invoking a destination Stedi function, the downstream function would be invoked with an input object in the following structure:

```typescript
{
  additionalInput: <ADDITIONAL_INPUT_FROM_CONFIG>,
  payload: <DESTINATION_PAYLOAD>,
}
```

This opinionated format made it impossible to, for example, invoke the `edi-outbound` function with the result of a mapping operation to automatically send an outbound EDI file. Customer #globecommerce-stedi encountered a use case where this would be useful.

**Updated behavior:**

Now the downstream function will be invoked with the raw destination payload, and if applicable the `additionalInput` from the configuration as well:

```typescript
{
  ...payload,
  ...additionalInput, // intentionally included second to support a use case of overriding something from the output payload
}
```

Additionally, failures encountered when invoking a function are now bubbled up correctly. Previously the only check was for successful invocation of the downstream function.

**Potential impact to existing users:**

As far as we are aware, the only customer using a function destination is #hampden-stedi (for a POC). We wrote their downstream function for them, and can easily update it if/when they want to upgrade to the latest bootstrap.


**Testing:**

In addition to the updated unit tests, I tested with a string payload for a downstream function (EDI from `edi-outbound`), as well as object payloads, both with and without `additionalInput`. I also verified that errors thrown by destination functions are correctly reflected by the caller:

![image](https://user-images.githubusercontent.com/39536918/227610398-b7d9c964-9135-4df4-b8ea-be85961326bd.png)
