### PR TITLE
feat: remove leading slashes from path when delivering to bucket destination

### DIFF
--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -87,6 +87,33 @@ test.serial(
 );
 
 test.serial(
+  "delivery via bucket removes preceding slashes from bucket path",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "//my-as2-trading-partner/outbound";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "bucket",
+        bucketName,
+        path,
+      },
+      payload,
+      destinationFilename,
+    });
+
+    const expectedPath = "my-as2-trading-partner/outbound";
+    t.deepEqual(buckets.calls()[0].args[0].input, {
+      bucketName,
+      key: `${expectedPath}/${destinationFilename}`,
+      body: payload,
+    });
+  }
+);
+
+test.serial(
   "delivery via function fails when payload is string but additionalInput object is configured",
   async (t) => {
     const functionName = "test-function";

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -17,7 +17,10 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be bucket)");
   }
 
-  const key = `${input.destination.path}/${input.destinationFilename}`;
+  // remove any leading slashes, if present, from bucket key prefix
+  const path = input.destination.path.replace(/^\/+/, "");
+
+  const key = `${path}/${input.destinationFilename}`;
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,


### PR DESCRIPTION
If an object is uploaded to a bucket with a leading slash (`/`) in the prefix, it leads to confusing behavior. This has definitely tripped me up in the past, and recently [tripped up a customer as well](https://stedi-inc.slack.com/archives/C04UZCY4SUB/p1679516175450919?thread_ts=1679505676.033679&cid=C04UZCY4SUB). To avoid this confusion, any leading slashes can be removed from the path when delivering to a bucket destination.