### PR TITLE
feat: support optional privateKey and passphrase in sftp config

### DIFF
--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -245,6 +245,56 @@ test.serial(
   }
 );
 
+test.serial(
+  "delivery via sftp includes privateKey and passphrase when connecting if included in config",
+  async (t) => {
+    const host = "test-host.sftp.com";
+    const port = 22;
+    const username = "test-user";
+    const password = "test-password";
+    const privateKey = "some-private-key-value";
+    const passphrase = "private-key-passphrase";
+    const remotePath = "/outbound";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "sftp",
+        connectionDetails: {
+          host,
+          port,
+          username,
+          password,
+          privateKey,
+          passphrase,
+        },
+        remotePath,
+      },
+      destinationFilename,
+      payload,
+    });
+
+    t.assert(
+      sftpStub.connect.calledOnceWith({
+        host,
+        port,
+        username,
+        password,
+        privateKey,
+        passphrase,
+      })
+    );
+    t.assert(
+      sftpStub.put.calledOnceWith(
+        Buffer.from(payload),
+        `${remotePath}/${destinationFilename}`
+      )
+    );
+    t.assert(sftpStub.end.calledOnceWith());
+  }
+);
+
 test.serial("delivery via webhook sends payload to expected url", async (t) => {
   const payload = "file-contents";
   const baseUrl = "https://webhook.site";

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -5,6 +5,8 @@ export const SftpConfigSchema = z.strictObject({
   port: z.number().default(22),
   username: z.string(),
   password: z.string(),
+  privateKey: z.string().optional(),
+  passphrase: z.string().optional(),
 });
 
 const WebhookVerbSchema = z.enum(["PATCH", "POST", "PUT"]);


### PR DESCRIPTION
A customer [needs to use privateKey + username password](https://stedi-inc.slack.com/archives/C04MDD11WHG/p1679511861118429?thread_ts=1679325106.165069&cid=C04MDD11WHG) authentication for their trading partner's SFTP. My initial thought was to try and just pass through all available SSH/SFTP connection options from the library we use, but I wasn't able to find a good way to go from an existing TS type to a Zod schema, so we can just add options as-needed for now.

Will open a mirror PR against the engine branch as well