### PR TITLE
feat(legacy): add support for replicating inbound documents

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,9 +2,9 @@ name: PR Test Suite
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main", "legacy" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main", "legacy" ]
 
 jobs:
   build:

--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -114,6 +114,32 @@ test.serial(
 );
 
 test.serial(
+  "delivery via bucket does insert preceding slash when path is empty",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "bucket",
+        bucketName,
+        path,
+      },
+      payload,
+      destinationFilename,
+    });
+
+    t.deepEqual(buckets.calls()[0].args[0].input, {
+      bucketName,
+      key: destinationFilename,
+      body: payload,
+    });
+  }
+);
+
+test.serial(
   "delivery via function fails when payload is string but additionalInput object is configured",
   async (t) => {
     const functionName = "test-function";

--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -140,6 +140,32 @@ test.serial(
 );
 
 test.serial(
+  "delivery via bucket does include preceding slash when path is set to `/`",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "/";
+    const destinationFilename = "850-0001.edi";
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "bucket",
+        bucketName,
+        path,
+      },
+      payload,
+      destinationFilename,
+    });
+
+    t.deepEqual(buckets.calls()[0].args[0].input, {
+      bucketName,
+      key: destinationFilename,
+      body: payload,
+    });
+  }
+);
+
+test.serial(
   "delivery via function fails when payload is string but additionalInput object is configured",
   async (t) => {
     const functionName = "test-function";

--- a/src/lib/__tests__/replication.unit.ts
+++ b/src/lib/__tests__/replication.unit.ts
@@ -1,0 +1,61 @@
+import test from "ava";
+import fs from "node:fs";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { mockBucketClient, mockStashClient } from "../testing/testHelpers.js";
+import { processReplication } from "../replication.js";
+
+const buckets = mockBucketClient();
+const stash = mockStashClient();
+
+const sample855 = fs.readFileSync(
+  "./src/resources/X12/5010/855/inbound.edi",
+  "utf8"
+);
+
+test.afterEach.always(() => {
+  buckets.reset();
+  stash.reset();
+});
+
+test.serial("replicates input to destination", async (t) => {
+  stash
+    .on(GetValueCommand, { key: "bootstrap|replication-config" })
+    .resolvesOnce({
+      value: {
+        destinations: [
+          {
+            destination: {
+              bucketName: "core-ingestion-bucket",
+              path: "replicated-documents",
+              type: "bucket",
+            },
+          },
+        ],
+      },
+    });
+
+  await processReplication({
+    currentKey: "trading_partners/ANOTHERMERCH/inbound/inbound.edi",
+    body: sample855,
+  });
+
+  t.like(buckets.calls()[0].args[0].input, {
+    bucketName: "core-ingestion-bucket",
+    key: "replicated-documents/inbound.edi",
+  });
+});
+
+test.serial("is a no-op if configuration does not exist", async (t) => {
+  stash
+    .on(GetValueCommand, { key: "bootstrap|replication-config" })
+    .resolvesOnce({
+      value: undefined,
+    });
+
+  await processReplication({
+    currentKey: "trading_partners/ANOTHERMERCH/inbound/inbound.edi",
+    body: sample855,
+  });
+
+  t.assert(buckets.calls().length === 0);
+});

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -20,7 +20,11 @@ export const deliverToDestination = async (
   // remove any leading slashes, if present, from bucket key prefix
   const path = input.destination.path.replace(/^\/+/, "");
 
-  const key = `${path}/${input.destinationFilename}`;
+  // prepend path to key if defined, otherwise key points to bucket root
+  const key = path ?
+    `${path}/${input.destinationFilename}`
+    : input.destinationFilename;
+
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,

--- a/src/lib/replication.ts
+++ b/src/lib/replication.ts
@@ -1,0 +1,47 @@
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+
+import { PARTNERS_KEYSPACE_NAME } from "./constants.js";
+import { Destination } from "./types/Destination.js";
+import { ReplicationConfigSchema } from "./types/ReplicationConfig.js";
+import { stashClient } from "./clients/stash.js";
+import {
+  DeliveryResult,
+  processDeliveries,
+  ProcessDeliveriesInput,
+} from "./deliveryManager.js";
+
+const keyspaceName = PARTNERS_KEYSPACE_NAME;
+const replicationConfigStashKey = "bootstrap|replication-config";
+
+export const processReplication = async ({
+  currentKey,
+  body,
+}: {
+  currentKey: string;
+  body: string;
+}): Promise<DeliveryResult[]> => {
+  const replicationDestinations = await getReplicationDestinations();
+  const replicationDeliveriesInput: ProcessDeliveriesInput = {
+    destinations: replicationDestinations,
+    payload: body,
+    destinationFilename: getReplicationFilenameFromKey(currentKey),
+  };
+
+  return await processDeliveries(replicationDeliveriesInput);
+};
+
+const getReplicationDestinations = async (): Promise<Destination[]> => {
+  const stashResponse = await stashClient().send(
+    new GetValueCommand({
+      keyspaceName,
+      key: replicationConfigStashKey,
+    })
+  );
+
+  return stashResponse.value
+    ? ReplicationConfigSchema.parse(stashResponse.value).destinations
+    : [];
+};
+
+const getReplicationFilenameFromKey = (currentKey: string): string =>
+  currentKey.split("/").pop() ?? currentKey;

--- a/src/lib/types/ReplicationConfig.ts
+++ b/src/lib/types/ReplicationConfig.ts
@@ -1,0 +1,7 @@
+import z from "zod";
+
+import { DestinationSchema } from "./Destination.js";
+
+export const ReplicationConfigSchema = z.strictObject({
+  destinations: z.array(DestinationSchema),
+});


### PR DESCRIPTION
- adds support for replicating inbound documents to destinations, via `bootstrap|replication-config` stash key using existing destinations schemas
- adds `legacy` branch to PR workflow config
- adds fix for object keys when destination bucket path is empty string (don't prefix key with `/`)