### PR TITLE
feat: include descriptive error name and details for schema parse errors

### DIFF
--- a/src/functions/edi/acknowledgment/__tests__/handler.invalid-config.ts
+++ b/src/functions/edi/acknowledgment/__tests__/handler.invalid-config.ts
@@ -1,0 +1,98 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import nock from "nock";
+import { sampleTranslationSucceededEvent } from "../__fixtures__/events.js";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockFunctionsClient,
+  mockGuideClient,
+  mockStashClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { InvokeFunctionCommand } from "@stedi/sdk-client-functions";
+import {
+  DestinationAck,
+  DestinationErrorEvents,
+} from "../../../../lib/types/Destination.js";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+
+const stash = mockStashClient();
+const guides = mockGuideClient();
+const functions = mockFunctionsClient();
+const buckets = mockBucketClient();
+
+const { partnershipId } = sampleTranslationSucceededEvent.detail.partnership;
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  guides.reset();
+  stash.reset();
+  functions.reset();
+  buckets.reset();
+});
+
+test.serial(
+  `processes incoming functional_group.processed event, throws error if stash configuration is incorrect`,
+  async (t) => {
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: `functional_acknowledgments|${partnershipId}`,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        key: `functional_acknowledgments|${partnershipId}`,
+        value: {
+          invalidValue: ["850"],
+        } as any as DestinationAck,
+      });
+
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: `destinations|errors|execution`,
+      })
+      .resolvesOnce({
+        key: `destinations|errors|execution`,
+        value: {
+          destinations: [
+            {
+              destination: {
+                type: "function",
+                functionName: "exception-function",
+              },
+            },
+          ],
+        } satisfies DestinationErrorEvents,
+      });
+
+    functions
+      .on(InvokeFunctionCommand, {
+        functionName: "exception-function",
+      })
+      .resolvesOnce({});
+
+    const error = await handler(sampleTranslationSucceededEvent).catch(
+      (e) => e
+    );
+
+    const exceptionFunctionCall = functions.commandCalls(
+      InvokeFunctionCommand,
+      {
+        functionName: "exception-function",
+      }
+    )[0]!;
+
+    t.truthy(exceptionFunctionCall);
+
+    const { payload: exceptionPayload } = exceptionFunctionCall.args[0].input;
+    t.is((exceptionPayload as any).error.name, "StashConfigurationError");
+    t.is((exceptionPayload as any).error.context.details.length, 2);
+    t.is(error.context.rawError.name, "StashConfigurationError");
+    t.is(error.context.rawError.context.details.length, 2);
+  }
+);

--- a/src/functions/edi/acknowledgment/handler.ts
+++ b/src/functions/edi/acknowledgment/handler.ts
@@ -15,6 +15,7 @@ import {
   DestinationAck,
   DestinationAckSchema,
 } from "../../../lib/types/Destination.js";
+import { ErrorFromStashConfiguration } from "../../../lib/errorFromStashConfiguration.js";
 
 const stash = stashClient();
 
@@ -51,9 +52,18 @@ const send997Acknowledgment = async (
     return;
   }
 
-  const ackConfig: DestinationAck = DestinationAckSchema.parse(
+  const ackConfigParseResult = DestinationAckSchema.safeParse(
     ackConfigResult.value
   );
+
+  if (!ackConfigParseResult.success) {
+    throw new ErrorFromStashConfiguration(
+      `functional_acknowledgments|${partnershipId}`,
+      ackConfigParseResult
+    );
+  }
+
+  const ackConfig: DestinationAck = ackConfigParseResult.data;
 
   const { functionalIdentifierCode, controlNumber } =
     event.detail.envelopes.functionalGroup;

--- a/src/lib/clients/stash.ts
+++ b/src/lib/clients/stash.ts
@@ -1,5 +1,10 @@
-import { StashClient, StashClientConfig } from "@stedi/sdk-client-stash";
+import {
+  GetValueCommand,
+  StashClient,
+  StashClientConfig,
+} from "@stedi/sdk-client-stash";
 import { DEFAULT_SDK_CLIENT_PROPS } from "../constants.js";
+import { ErrorFromStashConfiguration } from "../errorFromStashConfiguration.js";
 
 let _stashClient: StashClient | undefined;
 
@@ -16,4 +21,21 @@ export const stashClient = () => {
   }
 
   return _stashClient;
+};
+
+export const getRequiredValue = async (keyspaceName: string, key: string) => {
+  const result = await stashClient().send(
+    new GetValueCommand({
+      keyspaceName,
+      key,
+    })
+  );
+
+  if (!result.value) {
+    throw new ErrorFromStashConfiguration(key, {
+      error: { issues: [{ message: "Required key not found in stash" }] },
+    });
+  }
+
+  return result.value;
 };

--- a/src/lib/errorFromFunctionEvent.ts
+++ b/src/lib/errorFromFunctionEvent.ts
@@ -1,0 +1,11 @@
+import { SafeParseError } from "zod";
+import { ErrorWithContext } from "./errorWithContext.js";
+
+export class ErrorFromFunctionEvent extends ErrorWithContext {
+  constructor(functionName: string, error: SafeParseError<unknown>) {
+    super(`Invalid event sent to function: ${functionName}`, {
+      details: error.error.issues,
+    });
+    this.name = "InvalidFunctionEvent";
+  }
+}

--- a/src/lib/errorFromStashConfiguration.ts
+++ b/src/lib/errorFromStashConfiguration.ts
@@ -1,0 +1,14 @@
+import { ErrorWithContext } from "./errorWithContext.js";
+
+export class ErrorFromStashConfiguration extends ErrorWithContext {
+  constructor(
+    configurationKey: string,
+    // Zod safeParse result
+    parseResult: { error: { issues: { message: string }[] } }
+  ) {
+    super(`Invalid configuration for key: ${configurationKey}`, {
+      details: parseResult.error.issues,
+    });
+    this.name = "StashConfigurationError";
+  }
+}

--- a/src/lib/loadFileErrorDestinations.ts
+++ b/src/lib/loadFileErrorDestinations.ts
@@ -6,6 +6,7 @@ import {
   DestinationErrorEvents,
   DestinationErrorEventsSchema,
 } from "./types/Destination.js";
+import { ErrorFromStashConfiguration } from "./errorFromStashConfiguration.js";
 
 const stash = stashClient();
 
@@ -23,7 +24,17 @@ export const loadFileErrorDestinations =
         return { destinations: [] };
       }
 
-      return DestinationErrorEventsSchema.parse(value);
+      const errorDestinationParseResult =
+        DestinationErrorEventsSchema.safeParse(value);
+
+      if (!errorDestinationParseResult.success) {
+        throw new ErrorFromStashConfiguration(
+          destinationFileErrorEventsKey,
+          errorDestinationParseResult
+        );
+      }
+
+      return errorDestinationParseResult.data;
     } catch (error) {
       if (
         typeof error === "object" &&


### PR DESCRIPTION
When a user sets a configuration in Stash that is not valid against the schema, return an error message that maximises the chance the user can understand and resolve the issue themselves. Sets an exception name that is more descriptive (either a stash issue or a function event issue), and sets the context.details property to the zod issues array, which contains the specific validation errors. Include either the stash key name or the function name in the error message.

Error returned from a function now looks like:

```
{
  "context": {
    "rawError": {
      "context": {
        "details": [
          {
            "code": "invalid_type",
            "expected": "array",
            "received": "undefined",
            "path": [
              "generateFor"
            ],
            "message": "Required"
          },
          {
            "code": "unrecognized_keys",
            "keys": [
              "invalidValue"
            ],
            "path": [],
            "message": "Unrecognized key(s) in object: 'invalidValue'"
          }
        ]
      },
      "name": "StashConfigurationError",
      "message": "Invalid configuration for key: functional_acknowledgments|this-is-me_another-merchant"
    }
  }
}
```