### PR TITLE
fix: ensure all guideIds are replaced by restore script

### DIFF
--- a/src/scripts/restore.ts
+++ b/src/scripts/restore.ts
@@ -35,7 +35,7 @@ import { parseGuideId } from "../support/guide.js";
     try {
       const guide = await guides.send(new CreateGuideCommand(guideBody));
 
-      stashRaw = stashRaw.replace(oldGuidId, parseGuideId(guide.id!));
+      stashRaw = stashRaw.replaceAll(oldGuidId, parseGuideId(guide.id!));
     } catch (error) {
       if (
         typeof error === "object" &&


### PR DESCRIPTION
We hit this bug when migrating a customer, restore script was only replacing the first instance of the guideIds.