### PR TITLE
feat: enforce strict input type for edi-inbound, improve filename prefix based on stricter input

### DIFF
--- a/src/functions/edi/inbound/__fixtures__/events.ts
+++ b/src/functions/edi/inbound/__fixtures__/events.ts
@@ -1,4 +1,6 @@
-export const sampleTransactionProcessedEvent = {
+import { TransactionEventSchema } from "../../../../lib/types/TransactionEvent.js";
+
+export const sampleTransactionProcessedEvent = TransactionEventSchema.parse({
   version: "0",
   id: "fedbee6f-f48e-df69-f279-3fbc9fad6305",
   "detail-type": "transaction.processed",
@@ -64,4 +66,4 @@ export const sampleTransactionProcessedEvent = {
       },
     },
   },
-};
+});

--- a/src/functions/edi/inbound/__tests__/handler.success.ts
+++ b/src/functions/edi/inbound/__tests__/handler.success.ts
@@ -10,7 +10,7 @@ import {
   mockStashClient,
   mockTranslateClient,
 } from "../../../../lib/testing/testHelpers.js";
-import { GetObjectCommand } from "@stedi/sdk-client-buckets";
+import { GetObjectCommand, PutObjectCommand } from "@stedi/sdk-client-buckets";
 import { Readable } from "stream";
 import { GetValueCommand } from "@stedi/sdk-client-stash";
 import guideJSON855 from "../__fixtures__/855-guide.json" assert { type: "json" };
@@ -60,6 +60,13 @@ test.serial(
                 verb: "POST",
               },
             },
+            {
+              destination: {
+                type: "bucket",
+                bucketName: "another-merchant-edi",
+                path: "inbound/855",
+              },
+            },
           ],
         },
       });
@@ -74,6 +81,17 @@ test.serial(
     t.assert(
       webhookRequest.isDone(),
       "delivered guide JSON to destination webhook"
+    );
+
+    const bucketDestinationCall = buckets.commandCalls(PutObjectCommand, {
+      bucketName: "another-merchant-edi",
+    });
+
+    t.is(bucketDestinationCall.length, 1, "delivered guide JSON to bucket");
+    t.is(
+      bucketDestinationCall[0]!.args[0].input.key,
+      "inbound/855/1746-1746-1-855.json",
+      "sets filename prefix to control numbers"
     );
 
     t.deepEqual(result, {});

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -7,7 +7,10 @@ import {
 } from "../../../lib/execution.js";
 import { bucketsClient } from "../../../lib/clients/buckets.js";
 import { ErrorWithContext } from "../../../lib/errorWithContext.js";
-import { TransactionEventSchema } from "../../../lib/types/TransactionEvent.js";
+import {
+  TransactionEvent,
+  TransactionEventSchema,
+} from "../../../lib/types/TransactionEvent.js";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -25,7 +28,7 @@ import {
 const buckets = bucketsClient();
 
 export const handler = async (
-  event: unknown
+  event: TransactionEvent
 ): Promise<Record<string, unknown> | FailureResponse> => {
   console.log(JSON.stringify(event, null, 2));
   const executionId = generateExecutionId(event);

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -7,10 +7,7 @@ import {
 } from "../../../lib/execution.js";
 import { bucketsClient } from "../../../lib/clients/buckets.js";
 import { ErrorWithContext } from "../../../lib/errorWithContext.js";
-import {
-  TransactionEvent,
-  TransactionEventSchema,
-} from "../../../lib/types/TransactionEvent.js";
+import { TransactionEventSchema } from "../../../lib/types/TransactionEvent.js";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -28,7 +25,7 @@ import {
 const buckets = bucketsClient();
 
 export const handler = async (
-  event: TransactionEvent
+  event: unknown
 ): Promise<Record<string, unknown> | FailureResponse> => {
   console.log(JSON.stringify(event, null, 2));
   const executionId = generateExecutionId(event);

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -57,10 +57,8 @@ export const handler = async (
     });
 
     // prepare delivery payloads
-    const filenamePrefix = transactionEvent.detail.envelopes.interchange
-      .controlNumber
-      ? transactionEvent.detail.envelopes.interchange.controlNumber
-      : Date.now();
+    const { envelopes } = transactionEvent.detail;
+    const filenamePrefix = `${envelopes.interchange.controlNumber}-${envelopes.functionalGroup.controlNumber}-${transactionEvent.detail.transaction.controlNumber}`;
 
     const destinationFilename = generateDestinationFilename(
       filenamePrefix.toString(),


### PR DESCRIPTION
As the `edi-inbound` function only accepts `transaction.processed` events, we can tighten the input event type and improve on the filename prefix generation to leverage details from the event.