### PR TITLE
feat: allow destination filtering based on release

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,14 @@ npm run destroy
     },
     "usageIndicatorCode": {
       "$comment": "Optional. Only sends transaction sets with the specified usage indicator to the destination.",
+      "type": "string",
       "enum": ["P", "T", "I"]
+    },
+    "release": {
+      "$comment": "Optional. Only sends transaction sets with the specified release to the destination.",
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 12
     },
     "destination": {
       "oneOf": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "npm run configure-storage && npx ts-node-esm ./src/setup/bootstrap.ts && npm run deploy",
     "destroy": "ts-node-esm ./src/setup/destroy.ts",
     "deploy": "ts-node-esm ./src/setup/deploy.ts",
-    "configure-buckets": "ts-node-esm ./src/setup/configureBuckets.ts",
+    "build": "rm -rf ./dist && tsc --build",
     "upgrade-core": "ts-node-esm ./src/setup/upgradeCore.ts",
     "configure-storage": "npm run ensure-keyspaces-exist && npm run configure-buckets",
     "ensure-keyspaces-exist": "ts-node-esm ./src/setup/bootstrap/ensureKeyspacesExist.ts",

--- a/src/functions/edi/inbound/__tests__/handler.release.ts
+++ b/src/functions/edi/inbound/__tests__/handler.release.ts
@@ -1,0 +1,131 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import nock from "nock";
+import { sampleTransactionProcessedEvent } from "../__fixtures__/events.js";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockGuideClient,
+  mockStashClient,
+  mockTranslateClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { GetObjectCommand } from "@stedi/sdk-client-buckets";
+import { Readable } from "stream";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import guideJSON855 from "../__fixtures__/855-guide.json" assert { type: "json" };
+import { TransactionSetDestinations } from "../../../../lib/types/Destination";
+
+const buckets = mockBucketClient();
+const translate = mockTranslateClient();
+const stash = mockStashClient();
+const guides = mockGuideClient();
+
+const partnershipId = "this-is-me_another-merchant";
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  nock.cleanAll();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  buckets.reset();
+  guides.reset();
+  stash.reset();
+  translate.reset();
+});
+
+test.serial(
+  `processes incoming transaction.processed event, do not deliver to destination when release does not match`,
+  async (t) => {
+    // loading incoming EDI file from S3
+    buckets.on(GetObjectCommand, {}).resolves({
+      body: sdkStreamMixin(
+        Readable.from([new TextEncoder().encode(JSON.stringify(guideJSON855))])
+      ),
+    });
+
+    stash
+      .on(GetValueCommand, {
+        key: `destinations|${partnershipId}|855`,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          description:
+            "Purchase Order Acknowledgments received from ANOTHERMERCH",
+          destinations: [
+            {
+              release: "005010EXTEND",
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies TransactionSetDestinations,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => t.deepEqual(body, guideJSON855))
+      .reply(200, { thank: "you" });
+
+    const result = await handler(sampleTransactionProcessedEvent);
+
+    t.assert(
+      !webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+
+    t.deepEqual(result, {});
+  }
+);
+
+test.serial(
+  `processes incoming transaction.processed event, deliver to destination when release matches`,
+  async (t) => {
+    // loading incoming EDI file from S3
+    buckets.on(GetObjectCommand, {}).resolves({
+      body: sdkStreamMixin(
+        Readable.from([new TextEncoder().encode(JSON.stringify(guideJSON855))])
+      ),
+    });
+
+    stash
+      .on(GetValueCommand, {
+        key: `destinations|${partnershipId}|855`,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          description:
+            "Purchase Order Acknowledgments received from ANOTHERMERCH",
+          destinations: [
+            {
+              release: "005010",
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies TransactionSetDestinations,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => t.deepEqual(body, guideJSON855))
+      .reply(200, { thank: "you" });
+
+    const result = await handler(sampleTransactionProcessedEvent);
+
+    t.assert(
+      webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+
+    t.deepEqual(result, {});
+  }
+);

--- a/src/lib/deliveryManager.ts
+++ b/src/lib/deliveryManager.ts
@@ -26,7 +26,6 @@ export interface ProcessDeliveriesInput {
   destinations: Destination[];
   payload: object | string;
   destinationFilename: string;
-  envelopeUsageIndicator?: "P" | "T" | "I";
 }
 
 export interface DeliverToDestinationInput {
@@ -76,22 +75,16 @@ export const processDeliveries = async (
   input: ProcessDeliveriesInput
 ): Promise<DeliveryResult[]> => {
   const deliveryResults = await Promise.allSettled(
-    input.destinations
-      .filter(
-        (d) =>
-          !d.usageIndicatorCode ||
-          d.usageIndicatorCode === input.envelopeUsageIndicator
-      )
-      .map(async ({ destination, mappingId }) => {
-        console.log(`delivering to ${destination.type} destination`);
-        const deliverToDestinationInput: ProcessSingleDeliveryInput = {
-          destination,
-          payload: input.payload,
-          mappingId,
-          destinationFilename: input.destinationFilename,
-        };
-        return await processSingleDelivery(deliverToDestinationInput);
-      })
+    input.destinations.map(async ({ destination, mappingId }) => {
+      console.log(`delivering to ${destination.type} destination`);
+      const deliverToDestinationInput: ProcessSingleDeliveryInput = {
+        destination,
+        payload: input.payload,
+        mappingId,
+        destinationFilename: input.destinationFilename,
+      };
+      return await processSingleDelivery(deliverToDestinationInput);
+    })
   );
 
   const deliveryResultsByStatus = groupDeliveryResults(deliveryResults, input);

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -67,6 +67,14 @@ export const DestinationSchema = z.strictObject({
     .describe(
       "configure destination to receive the transaction set only when the envelope usage indicator code matches the supplied value"
     ),
+  release: z
+    .string()
+    .min(6)
+    .max(12)
+    .optional()
+    .describe(
+      "configure destination to receive the transaction set only when the envelope release matches the supplied value"
+    ),
   destination: z.discriminatedUnion("type", [
     DestinationAs2Schema,
     DestinationBucketSchema,


### PR DESCRIPTION
Destinations can specify a 'release' property. An inbound or outbound transaction will only be sent to a destination if the payload (inbound envelope or outbound metadata) release matches the destination release. If the destination does not specify a release then it will receive all matching transaction sets.

This follows the existing pattern for usage indicator code.