### PR TITLE
feat: add strict mode for mapping validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,241 +384,33 @@ npm run destroy
 
 ### Destinations
 
-<details><summary>JSON Schema (click to expand):</summary>
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "mappingId": {
-      "type": "string"
-    },
-    "usageIndicatorCode": {
-      "$comment": "Optional. Only sends transaction sets with the specified usage indicator to the destination.",
-      "type": "string",
-      "enum": ["P", "T", "I"]
-    },
-    "release": {
-      "$comment": "Optional. Only sends transaction sets with the specified release to the destination.",
-      "type": "string",
-      "minLength": 6,
-      "maxLength": 12
-    },
-    "destination": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "as2"
-            },
-            "connectorId": {
-              "type": "string"
-            }
-          },
-          "required": ["type", "connectorId"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "bucket"
-            },
-            "bucketName": {
-              "type": "string"
-            },
-            "path": {
-              "type": "string"
-            }
-          },
-          "required": ["type", "bucketName", "path"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "function"
-            },
-            "functionName": {
-              "type": "string"
-            },
-            "additionalInput": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          },
-          "required": ["type", "functionName"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "sftp"
-            },
-            "connectionDetails": {
-              "type": "object",
-              "properties": {
-                "host": {
-                  "type": "string"
-                },
-                "port": {
-                  "type": "number",
-                  "default": 22
-                },
-                "username": {
-                  "type": "string"
-                },
-                "password": {
-                  "type": "string"
-                }
-              },
-              "required": ["host", "username", "password"]
-            },
-            "remotePath": {
-              "type": "string",
-              "defailt": "/"
-            }
-          },
-          "required": ["type", "connectionDetails"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "webhook"
-            },
-            "url": {
-              "type": "string"
-            },
-            "verb": {
-              "type": "string",
-              "enum": ["PATCH", "POST", "PUT"],
-              "default": "POST"
-            },
-            "headers": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          },
-          "required": ["type", "url"]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "stash"
-            },
-            "keyspaceName": {
-              "type": "string"
-            },
-            "keyPrefix": {
-              "type": "string"
-            }
-          },
-          "required": ["type", "keyspaceName"]
-        }
-      ]
-    }
-  },
-  "required": ["destination"]
-}
-```
-
-</details>
-<br />
+- [AS2](./src/schemas/destination-as2.json)
+- [Bucket](./src/schemas/destination-bucket.json)
+- [Function](./src/schemas/destination-function.json)
+- [SFTP](./src/schemas/destination-sftp.json)
+- [Stash](./src/schemas/destination-stash.json)
+- [Webhook](./src/schemas/destination-webhook.json)
 
 #### Transaction set destination
 
 key: `destinations|${partnershipId}|${transactionSetId}`
 
-value (JSON Schema):
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "description": {
-      "type": "string"
-    },
-    "destinations": {
-      "type": "array",
-      "items": {
-        "$ref": "see destination type"
-      }
-    }
-  },
-  "required": ["destinations"]
-}
-```
+value: [JSON Schema](./src/schemas/transaction-destinations.json)
 
 ## Execution error destinations
 
 key: `destinations|errors|execution`
 
-value (JSON Schema):
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "description": {
-      "type": "string"
-    },
-    "destinations": {
-      "type": "array",
-      "items": {
-        "$ref": "see destination type"
-      }
-    }
-  },
-  "required": ["destinations"]
-}
-```
+value: [JSON Schema](./src/schemas/error-destinations.json)
 
 ### File error destinations
 
 key: `destinations|errors|execution`
 
-value (JSON Schema):
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "description": {
-      "type": "string"
-    },
-    "destinations": {
-      "type": "array",
-      "items": {
-        "$ref": "see destination type"
-      }
-    }
-  },
-  "required": ["destinations"]
-}
-```
+value: [JSON Schema](./src/schemas/error-destinations.json)
 
 ### Acknowledgment configuration
 
 key: `functional_acknowledgments|${partnershipId}`
 
-value (JSON Schema):
-
-```json
-{
-  "type": "object",
-  "properties": {
-    "generateFor": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "comment": "Transaction Set Id"
-      }
-    }
-  },
-  "required": ["generateFor"]
-}
-```
+value: [JSON Schema](./src/schemas/acknowledgment.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "json-schema-to-zod": "^0.6.3",
         "jszip": "^3.10.1",
         "lodash-es": "^4.17.21",
         "mockdate": "^3.0.5",
@@ -56,6 +57,36 @@
         "typescript": "^5.0.3",
         "umzug": "^3.2.1",
         "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@ava/typescript": {
@@ -2007,6 +2038,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3665,6 +3702,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
     },
     "node_modules/callsites": {
       "version": "4.0.0",
@@ -5450,6 +5493,20 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-0.6.3.tgz",
+      "integrity": "sha512-G/B51WWBeY1+ozbE4ZOPHblY8CJ5Frk5f4wUPynWfzkD0ysB2nXsrEnkRlx5UFNOe/WKFErMP/NAUhwK3nd4jg==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.1.0",
+        "@types/json-schema": "^7.0.9",
+        "prettier": "^2.4.1"
+      },
+      "bin": {
+        "json-schema-to-zod": "cli.js"
       }
     },
     "node_modules/json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "npm run configure-storage && npx ts-node-esm ./src/setup/bootstrap.ts && npm run deploy",
     "destroy": "ts-node-esm ./src/setup/destroy.ts",
     "deploy": "ts-node-esm ./src/setup/deploy.ts",
-    "build": "rm -rf ./dist && tsc --build",
+    "build": "rm -rf ./dist && npm run generate-schema-types && tsc --build",
     "upgrade-core": "ts-node-esm ./src/setup/upgradeCore.ts",
     "configure-buckets": "ts-node-esm ./src/setup/configureBuckets.ts",
     "configure-storage": "npm run ensure-keyspaces-exist && npm run configure-buckets",
@@ -17,7 +17,8 @@
     "migrate": "ts-node-esm ./src/setup/migrate.ts",
     "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ./node_modules/.bin/ava",
     "coverage": "DOTENV_CONFIG_PATH=.env.test c8 node -r dotenv/config ./node_modules/.bin/ava",
-    "lint": "npx eslint --fix \"src/**/*.ts\""
+    "lint": "npx eslint --fix \"src/**/*.ts\"",
+    "generate-schema-types": "ts-node-esm ./src/scripts/schema-zod-types.ts"
   },
   "author": "",
   "license": "ISC",
@@ -55,6 +56,7 @@
     "eslint": "^8.37.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "json-schema-to-zod": "^0.6.3",
     "jszip": "^3.10.1",
     "lodash-es": "^4.17.21",
     "mockdate": "^3.0.5",

--- a/src/functions/edi/inbound/__tests__/handler.delivery-failure-error.ts
+++ b/src/functions/edi/inbound/__tests__/handler.delivery-failure-error.ts
@@ -90,7 +90,7 @@ test("sends execution errors to error destination when runtime error occurs", as
   const errorWebhook = nock("https://example.com")
     .post("/error-webhook", (body: any) => {
       return (
-        body.error.context.rejected[0].destination.destination.url ===
+        body.error.context.rejected[0].destination.url ===
           "https://webhook.site/TESTING" &&
         body.error.context.rejected[0].payload &&
         body.error.context.rejected[0].error

--- a/src/functions/ftp/external-poller/pollers/ftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/ftpPoller.ts
@@ -7,10 +7,10 @@ import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
 import { bucketsClient } from "../../../../lib/clients/buckets.js";
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 import { ErrorWithContext } from "../../../../lib/errorWithContext.js";
+import { DestinationBucket } from "../../../../lib/types/DestinationBucket.js";
 
 const buckets = bucketsClient();
 

--- a/src/functions/ftp/external-poller/pollers/remotePoller.ts
+++ b/src/functions/ftp/external-poller/pollers/remotePoller.ts
@@ -1,6 +1,6 @@
 import { FileDetails, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
+import { DestinationBucket } from "../../../../lib/types/DestinationBucket.js";
 
 export abstract class RemotePoller {
   abstract getRemoteFileDetails(

--- a/src/functions/ftp/external-poller/pollers/sftpPoller.ts
+++ b/src/functions/ftp/external-poller/pollers/sftpPoller.ts
@@ -4,11 +4,11 @@ import sftp from "ssh2-sftp-client";
 import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 
 import { FileDetails, ProcessingError, RemoteFileDetails } from "../types.js";
-import { DestinationBucket } from "../../../../lib/types/Destination.js";
 import { ConnectionDetails } from "../../../../lib/types/RemoteConnectionConfig.js";
 import { RemotePoller } from "./remotePoller.js";
 import { ErrorWithContext } from "../../../../lib/errorWithContext.js";
 import { bucketsClient } from "../../../../lib/clients/buckets.js";
+import { DestinationBucket } from "../../../../lib/types/DestinationBucket.js";
 
 const buckets = bucketsClient();
 export class SftpPoller extends RemotePoller {

--- a/src/lib/destinations/function.ts
+++ b/src/lib/destinations/function.ts
@@ -1,7 +1,7 @@
 import { DocumentType } from "@aws-sdk/types";
 import { DeliverToDestinationInput } from "../deliveryManager.js";
 import { invokeFunction } from "../functions.js";
-import { DestinationFunction } from "../types/Destination.js";
+import { DestinationFunction } from "../types/DestinationFunction.js";
 
 export const deliverToDestination = async (
   input: DeliverToDestinationInput

--- a/src/lib/destinations/webhook.ts
+++ b/src/lib/destinations/webhook.ts
@@ -38,7 +38,7 @@ export const deliverToDestination = async (
   }
 
   return {
-    method,
+    method: method ?? "POST",
     url: input.destination.url,
     status: response.status,
   };

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -7,6 +7,7 @@ import {
   DeleteFunctionCommandOutput,
   InvocationType,
   InvokeFunctionCommand,
+  LogRetention,
   UpdateFunctionCommand,
   UpdateFunctionCommandOutput,
 } from "@stedi/sdk-client-functions";
@@ -72,7 +73,7 @@ export const createFunction = async (
       packageBucket: bucketName,
       packageKey: key,
       environmentVariables,
-
+      logRetention: LogRetention.THREE_MONTHS,
       timeout: 900,
     })
   );

--- a/src/lib/mappings.ts
+++ b/src/lib/mappings.ts
@@ -15,7 +15,8 @@ export const mappingsClient = (): MappingsClient => {
 
 export const invokeMapping = async (
   mappingId: string,
-  payload: unknown
+  payload: unknown,
+  mappingValidation?: "strict"
 ): Promise<object> => {
   // Execute mapping to transform API JSON input to Guide schema-based JSON
   try {
@@ -23,6 +24,7 @@ export const invokeMapping = async (
       new MapDocumentCommand({
         id: mappingId,
         content: payload as DocumentType,
+        validationMode: mappingValidation,
       })
     );
     console.log(`mapping result: ${JSON.stringify(mapResult)}`);

--- a/src/lib/types/Depreacted.ts
+++ b/src/lib/types/Depreacted.ts
@@ -1,6 +1,7 @@
 import z from "zod";
-import { DestinationSchema } from "./Destination.js";
+
 import { UsageIndicatorCodeSchema } from "./TransactionEvent.js";
+import { TransactionSetDestinationsSchema } from "./Destination.js";
 
 /*
  * WARNING: THE SCHEMAS & TYPES DECLARED BELOW ARE NOW DEPRECATED
@@ -11,7 +12,7 @@ import { UsageIndicatorCodeSchema } from "./TransactionEvent.js";
 const BaseTransactionSetSchema = z.strictObject({
   description: z.string().optional(),
   usageIndicatorCode: UsageIndicatorCodeSchema,
-  destinations: z.array(DestinationSchema),
+  destinations: z.array(TransactionSetDestinationsSchema),
 });
 
 // dedicated schema for "997" ack transaction set:

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -1,66 +1,22 @@
 import z from "zod";
+import {
+  DestinationWebhook,
+  DestinationWebhookSchema,
+} from "./DestinationWebhook.js";
+import { DestinationAS2Schema } from "./DestinationAS2.js";
+import { DestinationBucketSchema } from "./DestinationBucket.js";
+import { DestinationFunctionSchema } from "./DestinationFunction.js";
+import { DestinationSftpSchema } from "./DestinationSftp.js";
+import { DestinationStashSchema } from "./DestinationStash.js";
+import { DestinationAck, DestinationAckSchema } from "./DestinationAck.js";
 
-export const SftpConfigSchema = z.strictObject({
-  host: z.string(),
-  port: z.number().default(22),
-  username: z.string(),
-  password: z.string(),
-  privateKey: z.string().optional(),
-  passphrase: z.string().optional(),
-});
+type WebhookVerb = DestinationWebhook["verb"];
 
-const WebhookVerbSchema = z.enum(["PATCH", "POST", "PUT"]).optional();
-
-export type WebhookVerb = z.infer<typeof WebhookVerbSchema>;
-
-const DestinationWebhookSchema = z.strictObject({
-  type: z.literal("webhook"),
-  url: z.string(),
-  verb: WebhookVerbSchema.default("POST"),
-  headers: z
-    .record(
-      // `Content-Type` header override is not allowed
-      z.string().regex(/^(?!content-type).+$/i),
-      z.string()
-    )
-    .optional(),
-});
-
-export const DestinationBucketSchema = z.strictObject({
-  type: z.literal("bucket"),
-  bucketName: z.string(),
-  path: z.string(),
-});
-
-export type DestinationBucket = z.infer<typeof DestinationBucketSchema>;
-
-export const DestinationSftpSchema = z.strictObject({
-  type: z.literal("sftp"),
-  connectionDetails: SftpConfigSchema,
-  remotePath: z.string().default("/"),
-});
-
-const DestinationFunctionSchema = z.strictObject({
-  type: z.literal("function"),
-  functionName: z.string(),
-  additionalInput: z.record(z.string(), z.unknown()).optional(),
-});
-
-export type DestinationFunction = z.infer<typeof DestinationFunctionSchema>;
-
-const DestinationAs2Schema = DestinationBucketSchema.extend({
-  type: z.literal("as2"),
-  connectorId: z.string(),
-});
-
-const DestinationStashSchema = z.strictObject({
-  type: z.literal("stash"),
-  keyspaceName: z.string(),
-  keyPrefix: z.string().optional(),
-});
-
-export const DestinationSchema = z.strictObject({
+// custom definition in order to use discriminated union with good types, not
+// possible using json-schema-to-zod
+const DestinationSchema = z.strictObject({
   mappingId: z.string().optional(),
+  mappingValidation: z.enum(["strict"]).optional(),
   usageIndicatorCode: z
     .enum(["P", "T", "I"])
     .optional()
@@ -76,7 +32,7 @@ export const DestinationSchema = z.strictObject({
       "configure destination to receive the transaction set only when the envelope release matches the supplied value"
     ),
   destination: z.discriminatedUnion("type", [
-    DestinationAs2Schema,
+    DestinationAS2Schema,
     DestinationBucketSchema,
     DestinationFunctionSchema,
     DestinationSftpSchema,
@@ -85,30 +41,25 @@ export const DestinationSchema = z.strictObject({
   ]),
 });
 
-export type Destination = z.input<typeof DestinationSchema>;
-
-export const TransactionSetDestinationsSchema = z.strictObject({
+const TransactionSetDestinationsSchema = z.strictObject({
+  $schema: z.string().optional(),
   description: z.string().optional(),
   destinations: z.array(DestinationSchema),
 });
 
-export type TransactionSetDestinations = z.input<
+type TransactionSetDestinations = z.input<
   typeof TransactionSetDestinationsSchema
 >;
 
-export const destinationAckKey = (partnershipId: string) =>
+const destinationAckKey = (partnershipId: string) =>
   `functional_acknowledgments|${partnershipId}`;
 
-export const DestinationAckSchema = z.strictObject({
-  generateFor: z.array(z.string().describe("Transaction Set ID")),
-});
+const destinationExecutionErrorKey = "destinations|errors|execution";
 
-export type DestinationAck = z.infer<typeof DestinationAckSchema>;
+const destinationFileErrorEventsKey = "destinations|errors|file_error";
 
-export const destinationExecutionErrorKey = "destinations|errors|execution";
-
-export const destinationFileErrorEventsKey = "destinations|errors|file_error";
-
+// custom definition in order to use discriminated union with good types, not
+// possible using json-schema-to-zod
 const DestinationErrorSchema = z.strictObject({
   description: z.string().optional(),
   mappingId: z.string().optional(),
@@ -120,11 +71,23 @@ const DestinationErrorSchema = z.strictObject({
   ]),
 });
 
-export const DestinationErrorEventsSchema = z.strictObject({
+const DestinationErrorEventsSchema = z.strictObject({
+  $schema: z.string().optional(),
   description: z.string().optional(),
   destinations: z.array(DestinationErrorSchema),
 });
 
-export type DestinationErrorEvents = z.infer<
-  typeof DestinationErrorEventsSchema
->;
+type DestinationErrorEvents = z.infer<typeof DestinationErrorEventsSchema>;
+
+export {
+  destinationAckKey,
+  destinationExecutionErrorKey,
+  destinationFileErrorEventsKey,
+  TransactionSetDestinationsSchema,
+  TransactionSetDestinations,
+  DestinationAckSchema,
+  DestinationAck,
+  DestinationErrorEventsSchema,
+  DestinationErrorEvents,
+  WebhookVerb,
+};

--- a/src/lib/types/DestinationAS2.ts
+++ b/src/lib/types/DestinationAS2.ts
@@ -1,0 +1,13 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationAS2Schema = z
+  .object({
+    type: z.literal("as2"),
+    connectorId: z.string(),
+    bucketName: z.string(),
+    path: z.string(),
+  })
+  .strict();
+
+export type DestinationAS2 = z.infer<typeof DestinationAS2Schema>;

--- a/src/lib/types/DestinationAck.ts
+++ b/src/lib/types/DestinationAck.ts
@@ -1,0 +1,11 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationAckSchema = z
+  .object({
+    $schema: z.string().optional(),
+    generateFor: z.array(z.string().describe("Transaction Set Id")),
+  })
+  .strict();
+
+export type DestinationAck = z.infer<typeof DestinationAckSchema>;

--- a/src/lib/types/DestinationBucket.ts
+++ b/src/lib/types/DestinationBucket.ts
@@ -1,0 +1,12 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationBucketSchema = z
+  .object({
+    type: z.literal("bucket"),
+    bucketName: z.string(),
+    path: z.string(),
+  })
+  .strict();
+
+export type DestinationBucket = z.infer<typeof DestinationBucketSchema>;

--- a/src/lib/types/DestinationFunction.ts
+++ b/src/lib/types/DestinationFunction.ts
@@ -1,0 +1,12 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationFunctionSchema = z
+  .object({
+    type: z.literal("function"),
+    functionName: z.string(),
+    additionalInput: z.record(z.any()).optional(),
+  })
+  .strict();
+
+export type DestinationFunction = z.infer<typeof DestinationFunctionSchema>;

--- a/src/lib/types/DestinationSftp.ts
+++ b/src/lib/types/DestinationSftp.ts
@@ -1,0 +1,21 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationSftpSchema = z
+  .object({
+    type: z.literal("sftp"),
+    connectionDetails: z
+      .object({
+        host: z.string(),
+        port: z.number().default(22),
+        username: z.string(),
+        password: z.string().optional(),
+        privateKey: z.string().optional(),
+        passphrase: z.string().optional(),
+      })
+      .strict(),
+    remotePath: z.string().optional(),
+  })
+  .strict();
+
+export type DestinationSftp = z.infer<typeof DestinationSftpSchema>;

--- a/src/lib/types/DestinationStash.ts
+++ b/src/lib/types/DestinationStash.ts
@@ -1,0 +1,12 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationStashSchema = z
+  .object({
+    type: z.literal("stash"),
+    keyspaceName: z.string(),
+    keyPrefix: z.string().optional(),
+  })
+  .strict();
+
+export type DestinationStash = z.infer<typeof DestinationStashSchema>;

--- a/src/lib/types/DestinationWebhook.ts
+++ b/src/lib/types/DestinationWebhook.ts
@@ -1,0 +1,13 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const DestinationWebhookSchema = z
+  .object({
+    type: z.literal("webhook"),
+    url: z.string(),
+    verb: z.enum(["PATCH", "POST", "PUT"]).default("POST"),
+    headers: z.record(z.string()).optional(),
+  })
+  .strict();
+
+export type DestinationWebhook = z.infer<typeof DestinationWebhookSchema>;

--- a/src/lib/types/RemoteConnectionConfig.ts
+++ b/src/lib/types/RemoteConnectionConfig.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-
-import { DestinationBucketSchema, SftpConfigSchema } from "./Destination.js";
+import { DestinationSftpSchema } from "./DestinationSftp";
+import { DestinationBucketSchema } from "./DestinationBucket";
 
 const FtpConfigSchema = z.strictObject({
   host: z.string(),
@@ -22,7 +22,7 @@ const ConnectionDetailsSchema = z.discriminatedUnion("protocol", [
   }),
   z.strictObject({
     protocol: z.literal("sftp"),
-    config: SftpConfigSchema,
+    config: DestinationSftpSchema.shape.connectionDetails,
   }),
 ]);
 

--- a/src/schemas/acknowledgment.json
+++ b/src/schemas/acknowledgment.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/acknowledgment.json",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "generateFor": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Transaction Set Id"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "generateFor"
+  ]
+}

--- a/src/schemas/destination-as2.json
+++ b/src/schemas/destination-as2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-as2.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "as2"
+    },
+    "connectorId": {
+      "type": "string"
+    },
+    "bucketName": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "connectorId",
+    "bucketName",
+    "path"
+  ]
+}

--- a/src/schemas/destination-bucket.json
+++ b/src/schemas/destination-bucket.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-bucket.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "bucket"
+    },
+    "bucketName": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "bucketName",
+    "path"
+  ]
+}

--- a/src/schemas/destination-function.json
+++ b/src/schemas/destination-function.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-function.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "function"
+    },
+    "functionName": {
+      "type": "string"
+    },
+    "additionalInput": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "functionName"
+  ]
+}

--- a/src/schemas/destination-sftp.json
+++ b/src/schemas/destination-sftp.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-sftp.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "sftp"
+    },
+    "connectionDetails": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "number",
+          "default": 22
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "privateKey": {
+          "type": "string"
+        },
+        "passphrase": {
+          "type": "string"
+        }
+      },
+      "dependentRequired": {
+        "passphrase": [
+          "privateKey"
+        ]
+      },
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "username"
+      ]
+    },
+    "remotePath": {
+      "type": "string",
+      "defailt": "/"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "connectionDetails"
+  ]
+}

--- a/src/schemas/destination-stash.json
+++ b/src/schemas/destination-stash.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-stash.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "stash"
+    },
+    "keyspaceName": {
+      "type": "string"
+    },
+    "keyPrefix": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "keyspaceName"
+  ]
+}

--- a/src/schemas/destination-webhook.json
+++ b/src/schemas/destination-webhook.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/destination-webhook.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "const": "webhook"
+    },
+    "url": {
+      "type": "string"
+    },
+    "verb": {
+      "type": "string",
+      "enum": [
+        "PATCH",
+        "POST",
+        "PUT"
+      ],
+      "default": "POST"
+    },
+    "headers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "patternProperties": {
+        "^[cC]ontent-[tT]ype$": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "url"
+  ]
+}

--- a/src/schemas/error-destinations.json
+++ b/src/schemas/error-destinations.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/error-destination.json",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "destinations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "mappingId": {
+            "type": "string"
+          },
+          "mappingValidation": {
+            "type": "string",
+            "enum": [
+              "strict"
+            ]
+          },
+          "destination": {
+            "oneOf": [
+              {
+                "$ref": "./destination-bucket.json"
+              },
+              {
+                "$ref": "./destination-function.json"
+              },
+              {
+                "$ref": "./destination-stash.json"
+              },
+              {
+                "$ref": "./destination-webhook.json"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "destinations"
+  ]
+}

--- a/src/schemas/transaction-destinations.json
+++ b/src/schemas/transaction-destinations.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/transaction-destinations.json",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "destinations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "mappingId": {
+            "type": "string"
+          },
+          "mappingValidation": {
+            "type": "string",
+            "enum": [
+              "strict"
+            ]
+          },
+          "usageIndicatorCode": {
+            "description": "Optional. Only sends transaction sets with the specified usage indicator to the destination.",
+            "type": "string",
+            "enum": [
+              "P",
+              "T",
+              "I"
+            ]
+          },
+          "release": {
+            "description": "Optional. Only sends transaction sets with the specified release to the destination.",
+            "type": "string",
+            "minLength": 6,
+            "maxLength": 12
+          },
+          "destination": {
+            "oneOf": [
+              {
+                "$ref": "destination-as2.json"
+              },
+              {
+                "$ref": "destination-bucket.json"
+              },
+              {
+                "$ref": "destination-function.json"
+              },
+              {
+                "$ref": "destination-sftp.json"
+              },
+              {
+                "$ref": "destination-stash.json"
+              },
+              {
+                "$ref": "destination-webhook.json"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "destinations"
+  ]
+}

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -33,7 +33,9 @@ void (async () => {
     ? InvocationType.ASYNCHRONOUS
     : InvocationType.SYNCHRONOUS;
 
-  console.log(`Invoking function '${functionName}' with invocation type: ${invocationType}.`);
+  console.log(
+    `Invoking function '${functionName}' with invocation type: ${invocationType}.`
+  );
   const response = await invokeFunction(functionName, input);
 
   const resultsOutput = response

--- a/src/scripts/schema-zod-types.ts
+++ b/src/scripts/schema-zod-types.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import acknowledgment from "../schemas/acknowledgment.json" assert { type: "json" };
+import destinationAS2 from "../schemas/destination-as2.json" assert { type: "json" };
+import destinationBucket from "../schemas/destination-bucket.json" assert { type: "json" };
+import destinationFunction from "../schemas/destination-function.json" assert { type: "json" };
+import destinationSftp from "../schemas/destination-sftp.json" assert { type: "json" };
+import destinationStash from "../schemas/destination-stash.json" assert { type: "json" };
+import destinationWebhook from "../schemas/destination-webhook.json" assert { type: "json" };
+import fs from "node:fs";
+import { jsonSchemaToZodDereffed } from "json-schema-to-zod";
+
+// json-schema-to-zod dependency fix resolving child schemas
+process.chdir("src/schemas");
+await generateZod(acknowledgment, "DestinationAck");
+await generateZod(destinationAS2, "DestinationAS2");
+await generateZod(destinationBucket, "DestinationBucket");
+await generateZod(destinationFunction, "DestinationFunction");
+await generateZod(destinationSftp, "DestinationSftp");
+await generateZod(destinationStash, "DestinationStash");
+await generateZod(destinationWebhook, "DestinationWebhook");
+
+async function generateZod(
+  json: unknown,
+  name: string,
+  destinationFolder = "../lib/types"
+) {
+  const zodModule = await jsonSchemaToZodDereffed(json as any, name + "Schema");
+  const fileName =
+    destinationFolder +
+    (destinationFolder.endsWith("/") ? "" : "/") +
+    `${name}.ts`;
+  fs.mkdirSync(destinationFolder, { recursive: true });
+  fs.writeFileSync(
+    fileName,
+    `// generated from /scripts/schema-zod-types.ts#generateZod\n` +
+      zodModule +
+      `\nexport type ${name} = z.infer<typeof ${name + "Schema"}>;\n`
+  );
+
+  console.log(`added zod file: ${fileName}`);
+}

--- a/src/scripts/writeEdi.ts
+++ b/src/scripts/writeEdi.ts
@@ -25,7 +25,7 @@ const PO_NUMBER_KEY = "purchase-order-number";
 
   const iterations = Array.from(Array(loopCount).keys());
   const promises = iterations.map(async (iteration) => {
-    const date = new Date().toISOString().split("T")[0] || "2023-04-14";
+    const date = new Date().toISOString().split("T")[0] ?? "2023-04-14";
     const poNumberResponse = await stashClient().send(
       new IncrementValueCommand({
         keyspaceName: BUSINESS_IDS_KEYSPACE_NAME,
@@ -33,7 +33,7 @@ const PO_NUMBER_KEY = "purchase-order-number";
         amount: 1,
       })
     );
-    const poNumber = poNumberResponse.value ?? "1";
+    const poNumber = (poNumberResponse.value as number | undefined) ?? "1";
 
     const outboundPayload = Outbound850Schema.parse(DEFAULT_850_PAYLOAD);
     outboundPayload.payload.heading.beginning_segment_for_purchase_order_BEG.purchase_order_number_03 = `PO-${poNumber

--- a/src/setup/bootstrap/createStashRecords.ts
+++ b/src/setup/bootstrap/createStashRecords.ts
@@ -7,6 +7,10 @@ import { stashClient } from "../../lib/clients/stash.js";
 import { PARTNERS_KEYSPACE_NAME } from "../../lib/constants.js";
 import { requiredEnvVar } from "../../lib/environment.js";
 import { saveTransactionSetDestinations } from "../../lib/saveTransactionSetDestinations.js";
+import {
+  DestinationAck,
+  TransactionSetDestinations,
+} from "../../lib/types/Destination.js";
 
 export const createSampleStashRecords = async ({
   partnershipId,
@@ -24,6 +28,8 @@ export const createSampleStashRecords = async ({
   await saveTransactionSetDestinations(
     `destinations|${partnershipId}|${rule850.transactionSetIdentifier!}`,
     {
+      $schema:
+        "https://raw.githubusercontent.com/Stedi-Demos/bootstrap/main/src/schemas/transaction-destinations.json",
       description: "Purchase Orders sent to ANOTHERMERCH",
       destinations: [
         {
@@ -34,13 +40,15 @@ export const createSampleStashRecords = async ({
           },
         },
       ],
-    }
+    } satisfies TransactionSetDestinations
   );
 
   // inbound 855 from ANOTHERMERCH to THISISME
   await saveTransactionSetDestinations(
     `destinations|${partnershipId}|${rule855.transactionSetIdentifier!}`,
     {
+      $schema:
+        "https://raw.githubusercontent.com/Stedi-Demos/bootstrap/main/src/schemas/transaction-destinations.json",
       description: "Purchase Order Acknowledgments received from ANOTHERMERCH",
       destinations: [
         {
@@ -50,11 +58,13 @@ export const createSampleStashRecords = async ({
           },
         },
       ],
-    }
+    } satisfies TransactionSetDestinations
   );
 
   // outbound 997s to ANOTHERMERCH
   await saveTransactionSetDestinations(`destinations|${partnershipId}|997`, {
+    $schema:
+      "https://raw.githubusercontent.com/Stedi-Demos/bootstrap/main/src/schemas/transaction-destinations.json",
     description: "Outbound 997 Acknowledgments",
     destinations: [
       {
@@ -65,15 +75,17 @@ export const createSampleStashRecords = async ({
         },
       },
     ],
-  });
+  } satisfies TransactionSetDestinations);
 
   await stashClient().send(
     new SetValueCommand({
       keyspaceName: PARTNERS_KEYSPACE_NAME,
       key: `functional_acknowledgments|${partnershipId}`,
       value: {
+        $schema:
+          "https://raw.githubusercontent.com/Stedi-Demos/bootstrap/main/src/schemas/acknowledgment.json",
         generateFor: ["855"],
-      },
+      } satisfies DestinationAck,
     })
   );
 };


### PR DESCRIPTION
The configuration options for transaction destinations is updated to accept a 'mappingValidation' property with the value 'strict'. 

In order for customers to be successful in updating configurations, the stash item documentation was refactored to use json schemas. In addition, the stash items themselves can now have a $schema property for better linking back to the documentation. Adding $schema to a stash object will not activate validation checking.