### PR TITLE
feat: add support for `baseFilename` for as2, bucket, and sftp destinations

### DIFF
--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -16,7 +16,6 @@ import consumers from "stream/consumers";
 import { Readable } from "node:stream";
 import { loadTransactionDestinations } from "../../../lib/loadTransactionDestinations.js";
 import {
-  generateDestinationFilename,
   processDeliveries,
   ProcessDeliveriesInput,
 } from "../../../lib/deliveryManager.js";
@@ -58,13 +57,9 @@ export const handler = async (
 
     // prepare delivery payloads
     const { envelopes } = transactionEvent.detail;
-    const filenamePrefix = `${envelopes.interchange.controlNumber}-${envelopes.functionalGroup.controlNumber}-${transactionEvent.detail.transaction.controlNumber}`;
-
-    const destinationFilename = generateDestinationFilename(
-      filenamePrefix.toString(),
-      transactionEvent.detail.transaction.transactionSetIdentifier,
-      "json"
-    );
+    const payloadIdEnvelopeSegment = `${envelopes.interchange.controlNumber}-${envelopes.functionalGroup.controlNumber}`;
+    const payloadIdTransactionSegment = `${transactionEvent.detail.transaction.controlNumber}-${transactionEvent.detail.transaction.transactionSetIdentifier}`;
+    const payloadId = `${payloadIdEnvelopeSegment}-${payloadIdTransactionSegment}`;
 
     const { usageIndicatorCode } =
       transactionEvent.detail.envelopes.interchange;
@@ -79,7 +74,10 @@ export const handler = async (
     const processDeliveriesInput: ProcessDeliveriesInput = {
       destinations: filteredDestinations,
       payload: guideJSON,
-      destinationFilename,
+      payloadMetadata: {
+        payloadId,
+        format: "json",
+      },
     };
 
     await processDeliveries(processDeliveriesInput);

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -10,7 +10,6 @@ import {
 import {
   processSingleDelivery,
   ProcessSingleDeliveryInput,
-  generateDestinationFilename,
   groupDeliveryResults,
 } from "../../../lib/deliveryManager.js";
 import { lookupFunctionalIdentifierCode } from "../../../lib/lookupFunctionalIdentifierCode.js";
@@ -161,15 +160,15 @@ export const handler = async (
             event.metadata.useBuiltInGuide
           );
 
-          const destinationFilename = generateDestinationFilename(
-            isaControlNumber.toString(),
-            transactionSetIdentifier,
-            "edi"
-          );
+          const payloadId = `${isaControlNumber}-${gsControlNumber}-${transactionSetIdentifier}`;
+
           const deliverToDestinationInput: ProcessSingleDeliveryInput = {
             destination,
             payload: translation,
-            destinationFilename,
+            payloadMetadata: {
+              payloadId,
+              format: "edi",
+            },
           };
           return await processSingleDelivery(deliverToDestinationInput);
         })

--- a/src/functions/events/file-error/handler.ts
+++ b/src/functions/events/file-error/handler.ts
@@ -35,7 +35,7 @@ const sendErrorToDestination = async (event: CoreFileError) => {
     destinations: errorDestinations.destinations,
     payload: event,
     payloadMetadata: {
-      payloadId: `${event.detail.fileId}-${new Date().toUTCString()}`,
+      payloadId: `${event.detail.fileId}-${new Date().toISOString()}`,
       format: "json",
     },
   };

--- a/src/functions/events/file-error/handler.ts
+++ b/src/functions/events/file-error/handler.ts
@@ -34,7 +34,10 @@ const sendErrorToDestination = async (event: CoreFileError) => {
   const processDeliveriesInput: ProcessDeliveriesInput = {
     destinations: errorDestinations.destinations,
     payload: event,
-    destinationFilename: `${event.detail.fileId}-${new Date().toUTCString()}`,
+    payloadMetadata: {
+      payloadId: `${event.detail.fileId}-${new Date().toUTCString()}`,
+      format: "json",
+    },
   };
 
   await processDeliveries(processDeliveriesInput);

--- a/src/lib/__tests__/deliveryManager.unit.ts
+++ b/src/lib/__tests__/deliveryManager.unit.ts
@@ -7,7 +7,7 @@ import {
   mockBucketClient,
   mockFunctionsClient,
 } from "../testing/testHelpers.js";
-import { processSingleDelivery } from "../deliveryManager.js";
+import { PayloadMetadata, processSingleDelivery } from "../deliveryManager.js";
 import nock from "nock";
 import { InvokeFunctionCommand } from "@stedi/sdk-client-functions";
 import { DestinationSftp } from "../types/DestinationSftp.js";
@@ -33,7 +33,11 @@ test.serial(
   async (t) => {
     const bucketName = "test-as2-bucket";
     const path = "my-as2-trading-partner/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const connectorId = "my-as2-connector-id";
     const payload = "file-contents";
 
@@ -45,7 +49,7 @@ test.serial(
         connectorId,
       },
       payload: "file-contents",
-      destinationFilename,
+      payloadMetadata,
     });
 
     t.deepEqual(buckets.calls()[0]!.args[0].input, {
@@ -66,7 +70,11 @@ test.serial(
   async (t) => {
     const bucketName = "test-as2-bucket";
     const path = "my-as2-trading-partner/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const payload = "file-contents";
 
     await processSingleDelivery({
@@ -76,7 +84,39 @@ test.serial(
         path,
       },
       payload,
-      destinationFilename,
+      payloadMetadata,
+    });
+
+    t.deepEqual(buckets.calls()[0]!.args[0].input, {
+      bucketName,
+      key: `${path}/${destinationFilename}`,
+      body: payload,
+    });
+  }
+);
+
+test.serial(
+  "delivery via bucket includes baseFilename when specified",
+  async (t) => {
+    const bucketName = "test-as2-bucket";
+    const path = "my-as2-trading-partner/outbound";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const baseFilename = "my-base-filename";
+    const destinationFilename = `${payloadMetadata.payloadId}-${baseFilename}.${payloadMetadata.format}`;
+    const payload = "file-contents";
+
+    await processSingleDelivery({
+      destination: {
+        type: "bucket",
+        bucketName,
+        path,
+        baseFilename,
+      },
+      payload,
+      payloadMetadata,
     });
 
     t.deepEqual(buckets.calls()[0]!.args[0].input, {
@@ -92,7 +132,11 @@ test.serial(
   async (t) => {
     const bucketName = "test-as2-bucket";
     const path = "//my-as2-trading-partner/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const payload = "file-contents";
 
     await processSingleDelivery({
@@ -102,7 +146,7 @@ test.serial(
         path,
       },
       payload,
-      destinationFilename,
+      payloadMetadata,
     });
 
     const expectedPath = "my-as2-trading-partner/outbound";
@@ -132,7 +176,10 @@ test.serial(
             additionalInput,
           },
           payload,
-          destinationFilename: "unused",
+          payloadMetadata: {
+            payloadId: "some-id",
+            format: "json",
+          },
         }),
       {
         instanceOf: Error,
@@ -157,7 +204,10 @@ test.serial(
         functionName,
       },
       payload,
-      destinationFilename: "unused",
+      payloadMetadata: {
+        payloadId: "some-id",
+        format: "json",
+      },
     });
 
     t.deepEqual(functions.calls()[0]!.args[0].input, {
@@ -184,7 +234,10 @@ test.serial(
         additionalInput,
       },
       payload,
-      destinationFilename: "unused",
+      payloadMetadata: {
+        payloadId: "some-id",
+        format: "json",
+      },
     });
 
     t.deepEqual(functions.calls()[0]!.args[0].input, {
@@ -206,7 +259,11 @@ test.serial(
     const username = "test-user";
     const password = "test-password";
     const remotePath = "/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const payload = "file-contents";
 
     await processSingleDelivery({
@@ -220,7 +277,7 @@ test.serial(
         },
         remotePath,
       },
-      destinationFilename,
+      payloadMetadata,
       payload,
     });
 
@@ -252,7 +309,11 @@ test.serial(
     const privateKey = "some-private-key-value";
     const passphrase = "private-key-passphrase";
     const remotePath = "/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const payload = "file-contents";
 
     await processSingleDelivery({
@@ -268,7 +329,7 @@ test.serial(
         },
         remotePath,
       },
-      destinationFilename,
+      payloadMetadata,
       payload,
     });
 
@@ -300,7 +361,11 @@ test.serial(
     const username = "test-user";
     const password = "test-password";
     const remotePath = "/outbound";
-    const destinationFilename = "850-0001.edi";
+    const payloadMetadata: PayloadMetadata = {
+      payloadId: "850-0001",
+      format: "edi",
+    };
+    const destinationFilename = `${payloadMetadata.payloadId}.${payloadMetadata.format}`;
     const payload = "file-contents";
     const retries = 2;
     const readyTimeout = 1_000;
@@ -328,7 +393,7 @@ test.serial(
         },
         remotePath,
       },
-      destinationFilename,
+      payloadMetadata,
       payload,
     });
 
@@ -371,7 +436,10 @@ test.serial("delivery via webhook sends payload to expected url", async (t) => {
       url,
     },
     payload,
-    destinationFilename: "unused",
+    payloadMetadata: {
+      payloadId: "some-id",
+      format: "json",
+    },
   });
 
   t.assert(webhookRequest.isDone(), "delivered payload to destination webhook");

--- a/src/lib/destinations/as2.ts
+++ b/src/lib/destinations/as2.ts
@@ -11,6 +11,7 @@ import { bucketsClient } from "../clients/buckets.js";
 
 import {
   DeliverToDestinationInput,
+  generateDestinationFilename,
   payloadAsString,
 } from "../deliveryManager.js";
 
@@ -24,7 +25,11 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be as2)");
   }
 
-  const key = `${input.destination.path}/${input.destinationFilename}`;
+  const destinationFilename = generateDestinationFilename(
+    input.payloadMetadata,
+    input.destination.baseFilename
+  );
+  const key = `${input.destination.path}/${destinationFilename}`;
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,

--- a/src/lib/destinations/bucket.ts
+++ b/src/lib/destinations/bucket.ts
@@ -5,6 +5,7 @@ import {
 import { bucketsClient } from "../clients/buckets.js";
 import {
   DeliverToDestinationInput,
+  generateDestinationFilename,
   payloadAsString,
 } from "../deliveryManager.js";
 
@@ -20,7 +21,11 @@ export const deliverToDestination = async (
   // remove any leading slashes, if present, from bucket key prefix
   const path = input.destination.path.replace(/^\/+/, "");
 
-  const key = `${path}/${input.destinationFilename}`;
+  const destinationFilename = generateDestinationFilename(
+    input.payloadMetadata,
+    input.destination.baseFilename
+  );
+  const key = `${path}/${destinationFilename}`;
   const putCommandArgs: PutObjectCommandInput = {
     bucketName: input.destination.bucketName,
     key,

--- a/src/lib/destinations/sftp.ts
+++ b/src/lib/destinations/sftp.ts
@@ -2,6 +2,7 @@ import sftp from "ssh2-sftp-client";
 
 import {
   DeliverToDestinationInput,
+  generateDestinationFilename,
   payloadAsString,
 } from "../deliveryManager.js";
 
@@ -19,9 +20,13 @@ export const deliverToDestination = async (
     throw new Error("invalid destination type (must be sftp)");
   }
 
+  const destinationFilename = generateDestinationFilename(
+    input.payloadMetadata,
+    input.destination.baseFilename
+  );
   const remotePath = `${input.destination.remotePath ?? ""}${
     input.destination.remotePath?.endsWith("/") ? "" : "/"
-  }${input.destinationFilename}`;
+  }${destinationFilename}`;
   const { host, username } = input.destination.connectionDetails;
   const fileContents = payloadAsString(input.destinationPayload);
 

--- a/src/lib/destinations/stash.ts
+++ b/src/lib/destinations/stash.ts
@@ -1,6 +1,6 @@
 import { SetValueCommand } from "@stedi/sdk-client-stash";
 import { stashClient } from "../clients/stash.js";
-import { DeliverToDestinationInput } from "../deliveryManager.js";
+import { DeliverToDestinationInput, generateDestinationFilename } from "../deliveryManager.js";
 import { DocumentType } from "@aws-sdk/types";
 import { ErrorWithContext } from "../errorWithContext.js";
 
@@ -27,12 +27,16 @@ export const deliverToDestination = async (
     );
   }
 
+  const destinationFilename = generateDestinationFilename(
+    input.payloadMetadata,
+  );
+
   return await stash.send(
     new SetValueCommand({
       keyspaceName: input.destination.keyspaceName,
       key: `${input.destination.keyPrefix ?? ""}${
         input.destination.keyPrefix ? "/" : ""
-      }${input.destinationFilename}`,
+      }${destinationFilename}`,
       value: input.destinationPayload as DocumentType,
     })
   );

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -24,6 +24,7 @@ export interface FailureRecord {
   bucketName?: string;
   key: string;
 }
+
 export interface FailureResponse {
   statusCode: number;
   message: string;
@@ -151,7 +152,10 @@ export const sendFailureToDestinations = async (
   const processDeliveriesInput: ProcessDeliveriesInput = {
     destinations: errorDestinations.destinations,
     payload: failure,
-    destinationFilename: `${executionId}-${new Date().toUTCString()}`,
+    payloadMetadata: {
+      payloadId: `${executionId}-${new Date().toUTCString()}`,
+      format: "json",
+    },
   };
 
   await processDeliveries(processDeliveriesInput);

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -153,7 +153,7 @@ export const sendFailureToDestinations = async (
     destinations: errorDestinations.destinations,
     payload: failure,
     payloadMetadata: {
-      payloadId: `${executionId}-${new Date().toUTCString()}`,
+      payloadId: `${executionId}-${new Date().toISOString()}`,
       format: "json",
     },
   };

--- a/src/lib/types/DestinationAS2.ts
+++ b/src/lib/types/DestinationAS2.ts
@@ -7,6 +7,7 @@ export const DestinationAS2Schema = z
     connectorId: z.string(),
     bucketName: z.string(),
     path: z.string(),
+    baseFilename: z.string().optional(),
   })
   .strict();
 

--- a/src/lib/types/DestinationAS2.ts
+++ b/src/lib/types/DestinationAS2.ts
@@ -7,7 +7,10 @@ export const DestinationAS2Schema = z
     connectorId: z.string(),
     bucketName: z.string(),
     path: z.string(),
-    baseFilename: z.string().optional(),
+    baseFilename: z
+      .string()
+      .describe("Optional prefix added to output file")
+      .optional(),
   })
   .strict();
 

--- a/src/lib/types/DestinationBucket.ts
+++ b/src/lib/types/DestinationBucket.ts
@@ -6,7 +6,10 @@ export const DestinationBucketSchema = z
     type: z.literal("bucket"),
     bucketName: z.string(),
     path: z.string(),
-    baseFilename: z.string().optional(),
+    baseFilename: z
+      .string()
+      .describe("Optional prefix added to output file")
+      .optional(),
   })
   .strict();
 

--- a/src/lib/types/DestinationBucket.ts
+++ b/src/lib/types/DestinationBucket.ts
@@ -6,6 +6,7 @@ export const DestinationBucketSchema = z
     type: z.literal("bucket"),
     bucketName: z.string(),
     path: z.string(),
+    baseFilename: z.string().optional(),
   })
   .strict();
 

--- a/src/lib/types/DestinationSftp.ts
+++ b/src/lib/types/DestinationSftp.ts
@@ -100,6 +100,7 @@ export const DestinationSftpSchema = z
       })
       .strict(),
     remotePath: z.string().optional(),
+    baseFilename: z.string().optional(),
   })
   .strict();
 

--- a/src/lib/types/DestinationSftp.ts
+++ b/src/lib/types/DestinationSftp.ts
@@ -100,7 +100,10 @@ export const DestinationSftpSchema = z
       })
       .strict(),
     remotePath: z.string().optional(),
-    baseFilename: z.string().optional(),
+    baseFilename: z
+      .string()
+      .describe("Optional prefix added to output file")
+      .optional(),
   })
   .strict();
 

--- a/src/schemas/destination-as2.json
+++ b/src/schemas/destination-as2.json
@@ -16,6 +16,7 @@
       "type": "string"
     },
     "baseFilename": {
+      "description": "Optional prefix added to output file",
       "type": "string"
     }
   },

--- a/src/schemas/destination-as2.json
+++ b/src/schemas/destination-as2.json
@@ -14,6 +14,9 @@
     },
     "path": {
       "type": "string"
+    },
+    "baseFilename": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/destination-bucket.json
+++ b/src/schemas/destination-bucket.json
@@ -11,6 +11,9 @@
     },
     "path": {
       "type": "string"
+    },
+    "baseFilename": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/destination-bucket.json
+++ b/src/schemas/destination-bucket.json
@@ -13,6 +13,7 @@
       "type": "string"
     },
     "baseFilename": {
+      "description": "Optional prefix added to output file",
       "type": "string"
     }
   },

--- a/src/schemas/destination-sftp.json
+++ b/src/schemas/destination-sftp.json
@@ -151,6 +151,9 @@
     "remotePath": {
       "type": "string",
       "defailt": "/"
+    },
+    "baseFilename": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/schemas/destination-sftp.json
+++ b/src/schemas/destination-sftp.json
@@ -153,6 +153,7 @@
       "defailt": "/"
     },
     "baseFilename": {
+      "description": "Optional prefix added to output file",
       "type": "string"
     }
   },


### PR DESCRIPTION
- adds support for `baseFilename` for as2, bucket, and sftp destinations (required in order to support multiple output files on the same destination from a single input event)
- refactors `deliveryManager` input to use `PayloadMetadata` instead of `destinationFilename`, as not all destination types support filenames