### PR TITLE
feat: support legacy input for edi-outbound function

### DIFF
--- a/src/functions/edi/outbound/__tests__/handler.legacy.ts
+++ b/src/functions/edi/outbound/__tests__/handler.legacy.ts
@@ -1,0 +1,194 @@
+import test from "ava";
+import nock from "nock";
+import { reset, set } from "mockdate";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockPartnersClient,
+  mockStashClient,
+  mockTranslateClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { handler } from "../handler.js";
+import sampleOutboundEvent from "../../../../resources/X12/5010/850/outbound.json" assert { type: "json" };
+import {
+  GetX12PartnershipCommand,
+  GetX12PartnershipOutput,
+  IncrementX12ControlNumberCommand,
+  IncrementX12ControlNumberOutput,
+  Timezone,
+} from "@stedi/sdk-client-partners";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+import {
+  TranslateJsonToX12Command,
+  TranslateJsonToX12Output,
+} from "@stedi/sdk-client-edi-translate";
+
+const buckets = mockBucketClient();
+const partners = mockPartnersClient();
+const stash = mockStashClient();
+const translate = mockTranslateClient();
+
+const guideId = "850-guide-id";
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  set("2022-05-25T01:02:03.451Z");
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  buckets.reset();
+  partners.reset();
+  stash.reset();
+  translate.reset();
+  reset();
+});
+
+test("using legacy function input, it translates guide json to X12 and delivers to destination", async (t) => {
+  partners
+    // load partnership
+    .on(GetX12PartnershipCommand as any, {
+      partnershipId: "another-merchant_this-is-me",
+    })
+    .resolvesOnce({})
+    // load partnership
+    .on(GetX12PartnershipCommand as any, {
+      partnershipId: "this-is-me_another-merchant",
+    })
+    .resolves({
+      partnershipId: "this-is-me_another-merchant",
+      localProfileId: "this-is-me",
+      localProfile: {
+        interchangeQualifier: "ZZ",
+        interchangeId: "THISISME",
+        profileId: "this-is-me",
+        profileType: "local",
+        defaultApplicationId: "meId",
+      },
+      partnerProfileId: "another-merchant",
+      partnerProfile: {
+        interchangeQualifier: "14",
+        interchangeId: "ANOTHERMERCH",
+        profileId: "another-merchant",
+        profileType: "partner",
+        defaultApplicationId: "merchId",
+      },
+      outboundTransactions: [
+        {
+          transactionSetIdentifier: "850",
+          outboundX12TransactionSettingsId: "850-transaction-rule-id",
+          guideId,
+          release: "008010",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      inboundTransactions: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      timezone: Timezone.AMERICA_NEW_YORK,
+      interchangeUsageIndicator: "T",
+    } satisfies GetX12PartnershipOutput as any)
+    // increment interchange control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "interchange",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "interchange",
+    } satisfies IncrementX12ControlNumberOutput as any)
+    // increment group control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "group",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "group",
+    } satisfies IncrementX12ControlNumberOutput as any);
+
+  stash
+    // loading destinations
+    .on(GetValueCommand, {
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: `destinations|this-is-me_another-merchant|850`,
+    })
+    .resolvesOnce({
+      value: {
+        description: "850 Outbound",
+        destinations: [
+          {
+            destination: {
+              type: "webhook",
+              url: "https://example.com/webhook",
+            },
+          },
+        ],
+      },
+    });
+
+  translate
+    // convert guide JSON to x12
+    .on(TranslateJsonToX12Command)
+    .resolvesOnce({ output: "ISA*" } satisfies TranslateJsonToX12Output);
+
+  // mock webhook request
+  const webhookRequest = nock("https://example.com")
+    .post("/webhook")
+    .reply(200, { ok: true });
+
+  const legacyEvent = {
+    ...sampleOutboundEvent,
+    metadata: {
+      sendingPartnerId: "this-is-me",
+      receivingPartnerId: "another-merchant",
+      release: "008010",
+    },
+  };
+
+  const response = await handler(legacyEvent as any);
+
+  t.is(response.statusCode, 200, "completes successfully");
+
+  t.assert(webhookRequest.isDone(), "webhook request was made");
+
+  const translateArgs = translate.commandCalls(TranslateJsonToX12Command)[0]!
+    .args[0].input;
+  t.is(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    (translateArgs.envelope as any).groupHeader.applicationReceiverCode,
+    "merchId",
+    "default applicationId is used for receiver"
+  );
+
+  t.is(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    (translateArgs.envelope as any).groupHeader.applicationSenderCode,
+    "meId",
+    "default applicationId is used for sender"
+  );
+
+  t.is(
+    (translateArgs.envelope as any).interchangeHeader.date,
+    "2022-05-24",
+    "date is set in partner configured timezone"
+  );
+
+  t.is(
+    (translateArgs.envelope as any).interchangeHeader.time,
+    "21:02",
+    "time is set in partner configured timezone"
+  );
+
+  t.is(
+    (translateArgs.envelope as any).groupHeader.date,
+    "2022-05-24",
+    "date is set in partner configured timezone"
+  );
+
+  t.is(
+    (translateArgs.envelope as any).groupHeader.time,
+    "21:02:03",
+    "time is set in partner configured timezone"
+  );
+});

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -15,6 +15,7 @@ import {
 import { lookupFunctionalIdentifierCode } from "../../../lib/lookupFunctionalIdentifierCode.js";
 import { invokeMapping } from "../../../lib/mappings.js";
 import {
+  LegacyOutboundEvent,
   LegacyOutboundEventSchema,
   OutboundEvent,
   OutboundEventSchema,
@@ -34,7 +35,7 @@ import { NoUndefined } from "../../../lib/types/NoUndefined.js";
 const partners = partnersClient();
 
 export const handler = async (
-  event: unknown
+  event: OutboundEvent | LegacyOutboundEvent
 ): Promise<Record<string, unknown> | FailureResponse> => {
   const executionId = generateExecutionId(event);
 

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -15,6 +15,7 @@ import {
 import { lookupFunctionalIdentifierCode } from "../../../lib/lookupFunctionalIdentifierCode.js";
 import { invokeMapping } from "../../../lib/mappings.js";
 import {
+  LegacyOutboundEventSchema,
   OutboundEvent,
   OutboundEventSchema,
 } from "../../../lib/types/OutboundEvent.js";
@@ -22,34 +23,29 @@ import { ErrorWithContext } from "../../../lib/errorWithContext.js";
 import { loadPartnershipById } from "../../../lib/loadPartnershipById.js";
 import { EdiTranslateWriteEnvelope } from "../../../lib/types/EdiTranslateWriteEnvelope.js";
 import { partnersClient } from "../../../lib/clients/partners.js";
-import { IncrementX12ControlNumberCommand } from "@stedi/sdk-client-partners";
+import {
+  GetX12PartnershipCommandOutput,
+  IncrementX12ControlNumberCommand,
+} from "@stedi/sdk-client-partners";
 import { loadTransactionDestinations } from "../../../lib/loadTransactionDestinations.js";
 import { ErrorFromFunctionEvent } from "../../../lib/errorFromFunctionEvent.js";
+import { NoUndefined } from "../../../lib/types/NoUndefined.js";
 
 const partners = partnersClient();
 
 export const handler = async (
-  event: OutboundEvent
+  event: unknown
 ): Promise<Record<string, unknown> | FailureResponse> => {
   const executionId = generateExecutionId(event);
 
   try {
     await recordNewExecution(executionId, event);
 
-    const outboundEventParseResult = OutboundEventSchema.safeParse(event);
-
-    if (!outboundEventParseResult.success) {
-      throw new ErrorFromFunctionEvent(
-        `edi-outbound`,
-        outboundEventParseResult
-      );
-    }
-
-    const outboundEvent = outboundEventParseResult.data;
+    const outboundEvent = await prepapreEvent(event);
 
     // load the outbound x12 configuration for the sender
     const partnership = await loadPartnershipById({
-      partnershipId: event.metadata.partnershipId,
+      partnershipId: outboundEvent.metadata.partnershipId,
     });
 
     // get the transaction set from Guide JSON or event metadata
@@ -61,7 +57,8 @@ export const handler = async (
     const transactionSetConfig = partnership.outboundTransactions?.find(
       (txn) =>
         txn.transactionSetIdentifier === transactionSetIdentifier &&
-        (!event.metadata.release || txn.release === event.metadata.release)
+        (!outboundEvent.metadata.release ||
+          txn.release === outboundEvent.metadata.release)
     );
 
     if (transactionSetConfig === undefined)
@@ -70,7 +67,7 @@ export const handler = async (
       );
 
     const transactionSetDestinations = await loadTransactionDestinations({
-      partnershipId: event.metadata.partnershipId,
+      partnershipId: outboundEvent.metadata.partnershipId,
       transactionSetIdentifier,
     });
 
@@ -112,7 +109,7 @@ export const handler = async (
         ),
         time: formatInTimeZone(documentDate, partnership.timezone, "HH:mm"),
         controlNumber: isaControlNumber.toString().padStart(9, "0"),
-        usageIndicatorCode: event.metadata.usageIndicatorCode,
+        usageIndicatorCode: outboundEvent.metadata.usageIndicatorCode,
         controlVersionNumber: transactionSetConfig.release.slice(
           0,
           5
@@ -157,7 +154,7 @@ export const handler = async (
             guideJson,
             transactionSetConfig.guideId,
             envelope,
-            event.metadata.useBuiltInGuide
+            outboundEvent.metadata.useBuiltInGuide
           );
 
           const payloadId = `${isaControlNumber}-${gsControlNumber}-${transactionSetIdentifier}`;
@@ -287,4 +284,54 @@ const filterDestination = (
   }
 
   return true;
+};
+
+const prepapreEvent = async (event: unknown): Promise<OutboundEvent> => {
+  // check if we have a legacy event input
+  const legacyEventParse = LegacyOutboundEventSchema.safeParse(event);
+  if (legacyEventParse.success) {
+    // check if we can resolve the partnership using the legacy event
+    let partnership: NoUndefined<GetX12PartnershipCommandOutput> | undefined;
+    try {
+      partnership = await loadPartnershipById({
+        partnershipId: `${legacyEventParse.data.metadata.sendingPartnerId}_${legacyEventParse.data.metadata.receivingPartnerId}`,
+      });
+    } catch (error) {
+      // swallow error
+    }
+
+    if (partnership === undefined) {
+      try {
+        partnership = await loadPartnershipById({
+          partnershipId: `${legacyEventParse.data.metadata.receivingPartnerId}_${legacyEventParse.data.metadata.sendingPartnerId}`,
+        });
+      } catch (error) {
+        // swallow error
+      }
+    }
+
+    if (partnership === undefined)
+      throw new ErrorWithContext(
+        "Legacy input used for edi-outbound, but no partnership found",
+        legacyEventParse.data
+      );
+
+    // reshape legacy event to new event format
+    event = {
+      metadata: {
+        partnershipId: partnership.partnershipId,
+        usageIndicatorCode: "P", // Do we default to P?
+        release: legacyEventParse.data.metadata.release,
+        transactionSet: legacyEventParse.data.metadata.transactionSet,
+      },
+      payload: legacyEventParse.data.payload,
+    };
+  }
+
+  const outboundEventParseResult = OutboundEventSchema.safeParse(event);
+
+  if (!outboundEventParseResult.success)
+    throw new ErrorFromFunctionEvent(`edi-outbound`, outboundEventParseResult);
+
+  return outboundEventParseResult.data;
 };

--- a/src/lib/types/OutboundEvent.ts
+++ b/src/lib/types/OutboundEvent.ts
@@ -20,3 +20,23 @@ export const OutboundEventSchema = z.strictObject({
 });
 
 export type OutboundEvent = z.infer<typeof OutboundEventSchema>;
+
+// this type is used for detecting legacy function input
+// this will be retired in a future version
+//
+export const LegacyOutboundEventSchema = z.strictObject({
+  metadata: z.strictObject({
+    sendingPartnerId: z.string(),
+    receivingPartnerId: z.string(),
+    transactionSet: z.string().optional(),
+    release: z
+      .string()
+      .optional()
+      .describe(
+        "selects a guide with a specific release when multiple guides are configured for the same transaction set"
+      ),
+  }),
+  payload: z.array(z.unknown()).or(z.record(z.unknown())).or(z.string()),
+});
+
+export type LegacyOutboundEvent = z.infer<typeof OutboundEventSchema>;


### PR DESCRIPTION
Updates `edi-outbound` to accept and transform legacy input, intended to allow production Bootstrap `legacy` branch usage to be upgraded to Core / `main` without interruption. 

Closes https://github.com/Stedi-Demos/bootstrap/issues/143