### PR TITLE
fix: use the error message from the original exception when returning

### DIFF
--- a/src/functions/edi/acknowledgment/__tests__/handler.invalid-config.ts
+++ b/src/functions/edi/acknowledgment/__tests__/handler.invalid-config.ts
@@ -92,7 +92,7 @@ test.serial(
     const { payload: exceptionPayload } = exceptionFunctionCall.args[0].input;
     t.is((exceptionPayload as any).error.name, "StashConfigurationError");
     t.is((exceptionPayload as any).error.context.details.length, 2);
-    t.is(error.context.rawError.name, "StashConfigurationError");
-    t.is(error.context.rawError.context.details.length, 2);
+    t.is(error.name, "StashConfigurationError");
+    t.is(error.context.details.length, 2);
   }
 );

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -94,7 +94,8 @@ export const handler = async (
   } catch (e) {
     const error = ErrorWithContext.fromUnknown(e);
 
-    return failedExecution(executionId, error);
+    const failureResponse = await failedExecution(executionId, error);
+    return failureResponse;
   }
 };
 

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -196,7 +196,11 @@ export const handler = async (
   } catch (e) {
     console.error(e);
     const errorWithContext = ErrorWithContext.fromUnknown(e);
-    return failedExecution(executionId, errorWithContext);
+    const failureResponse = await failedExecution(
+      executionId,
+      errorWithContext
+    );
+    return failureResponse;
   }
 };
 

--- a/src/functions/events/file-error/handler.ts
+++ b/src/functions/events/file-error/handler.ts
@@ -23,7 +23,8 @@ export const handler = async (event: CoreFileError) => {
     return {};
   } catch (e) {
     const error = ErrorWithContext.fromUnknown(e);
-    return failedExecution(executionId, error);
+    const failureResponse = await failedExecution(executionId, error);
+    return failureResponse;
   }
 };
 

--- a/src/functions/ftp/external-poller/handler.ts
+++ b/src/functions/ftp/external-poller/handler.ts
@@ -115,7 +115,8 @@ export const handler = async (
     return results;
   } catch (e) {
     const error = ErrorWithContext.fromUnknown(e);
-    return failedExecution(executionId, error);
+    const failureResponse = await failedExecution(executionId, error);
+    return failureResponse;
   }
 };
 

--- a/src/lib/errorWithContext.ts
+++ b/src/lib/errorWithContext.ts
@@ -1,14 +1,25 @@
 import { serializeError } from "serialize-error";
 
 export class ErrorWithContext extends Error {
-  constructor(message: string, public readonly context: object) {
-    super(message);
+  constructor(
+    message: string,
+    public readonly context: object | { rawError: Error } | Error
+  ) {
+    const cause =
+      "cause" in context
+        ? context.cause
+        : "rawError" in context
+        ? context.rawError.cause
+        : undefined;
+    super(message, { cause });
     this.name = "ErrorWithContext";
   }
 
   static fromUnknown(e: unknown) {
     return e instanceof ErrorWithContext
       ? e
-      : new ErrorWithContext(`unknown error`, { context: serializeError(e) });
+      : e instanceof Error
+      ? new ErrorWithContext(e.message, serializeError(e))
+      : new ErrorWithContext(`unknown error`, serializeError(e));
   }
 }

--- a/src/lib/execution.ts
+++ b/src/lib/execution.ts
@@ -92,10 +92,9 @@ export const failedExecution = async (
   const statusCode: number =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     ((errorWithContext as any)?.$metadata?.httpStatusCode as number) || 500;
-  const message = "execution failed";
   const failureResponse = {
     statusCode,
-    message,
+    message: errorWithContext.message,
     failureRecord,
     error: rawError,
   };
@@ -108,7 +107,7 @@ export const failedExecution = async (
       `failure-error-destination.json`
     );
   }
-  throw new ErrorWithContext(message, { rawError });
+  throw errorWithContext;
 };
 
 const markExecutionAsFailed = async (

--- a/src/setup/deploy.ts
+++ b/src/setup/deploy.ts
@@ -2,11 +2,11 @@ import { getFunctionPaths } from "../support/utils.js";
 import { waitUntilEventToFunctionBindingCreateComplete } from "@stedi/sdk-client-events";
 import { eventsClient } from "../lib/clients/events.js";
 import { updateResourceMetadata } from "../support/bootstrapMetadata.js";
-import { maxWaitTime } from "../support/contants.js";
 import {
   createOrUpdateEventBinding,
   deployFunctionAtPath,
 } from "../lib/functions.js";
+import { maxWaitTime } from "../support/contants.js";
 
 const events = eventsClient();
 


### PR DESCRIPTION
Previously the error message was a hard-coded 'execution failed', this meant the DLQ did not show descriptive messages. The stack trace was also limited and did not show the full error trace due to a new error object being constructed.

Now the ErrorWithContext uses the 'cause' property where possible to preserve the original stack trace, and the error message re-uses the original error message. The ErrorWithContext 'context' property has been simplified to make it more usable.

Also fixes deployment error logging, which previously did not print error objects.

Before:

<img width="746" alt="Screenshot 2023-05-03 at 12 07 28" src="https://user-images.githubusercontent.com/1443442/235901088-2c4b3ffb-addf-4d98-9be7-9217ca12ee7e.png">


Now:

<img width="1161" alt="Screenshot 2023-05-03 at 12 13 21" src="https://user-images.githubusercontent.com/1443442/235901122-39c7fc80-3df5-4d62-8c3d-7840091721a0.png">

With good stack trace:

<img width="1162" alt="Screenshot 2023-05-03 at 12 13 32" src="https://user-images.githubusercontent.com/1443442/235901173-a2a02bcc-a6df-409b-bc38-63aa35f7c185.png">

