### PR TITLE
feat: add optional billing usage poller function

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "coverage": "DOTENV_CONFIG_PATH=.env.test c8 node -r dotenv/config ./node_modules/.bin/ava",
     "lint": "npx eslint --fix \"src/**/*.ts\"",
     "generate-schema-types": "ts-node-esm ./src/scripts/schema-zod-types.ts",
-    "deploy-transform-split-loop": "ts-node-esm ./src/optional-functions/transform/split-loop/deploy.ts"
+    "deploy-transform-split-loop": "ts-node-esm ./src/optional-functions/transform/split-loop/deploy.ts",
+    "deploy-billing-usage-poller": "ts-node-esm ./src/optional-functions/billing/usage-poller/deploy.ts"
   },
   "author": "",
   "license": "ISC",

--- a/src/optional-functions/billing/usage-poller/Configuration.ts
+++ b/src/optional-functions/billing/usage-poller/Configuration.ts
@@ -1,0 +1,27 @@
+// generated from /scripts/schema-zod-types.ts#generateZod
+import { z } from "zod";
+
+export const ConfigurationSchema = z
+  .object({
+    $schema: z.string().optional(),
+    description: z.string().optional(),
+    destinations: z.array(
+      z
+        .object({
+          description: z.string().optional(),
+          threshold: z.number().gte(1).describe("the"),
+          destination: z
+            .object({
+              type: z.literal("webhook"),
+              url: z.string(),
+              verb: z.enum(["PATCH", "POST", "PUT"]).default("POST"),
+              headers: z.record(z.string()).optional(),
+            })
+            .strict(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+export type Configuration = z.infer<typeof ConfigurationSchema>;

--- a/src/optional-functions/billing/usage-poller/__tests__/handler.usage-threshold.ts
+++ b/src/optional-functions/billing/usage-poller/__tests__/handler.usage-threshold.ts
@@ -1,0 +1,191 @@
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import test from "ava";
+import { reset, set } from "mockdate";
+import nock from "nock";
+import { z } from "zod";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+import { mockStashClient } from "../../../../lib/testing/testHelpers.js";
+import { ConfigurationSchema } from "../Configuration.js";
+import { configurationKey } from "../constants.js";
+import { handler } from "../handler.js";
+
+const stash = mockStashClient();
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  set("2022-05-20T01:02:03.451Z");
+});
+
+test.afterEach.always(() => {
+  stash.reset();
+  reset();
+});
+
+test.serial(
+  `sends message to destination when expected usage threshold is exceeded`,
+  async (t) => {
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: configurationKey,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          destinations: [
+            {
+              threshold: 500,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+            {
+              threshold: 1_500,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING_2",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies z.input<typeof ConfigurationSchema>,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => {
+        return (
+          body.threshold === 500 &&
+          // use range to account for developer machine timezone differences
+          body.estimatedUsage > 557 &&
+          body.estimatedUsage < 576
+        );
+      })
+      .once()
+      .reply(200, {});
+
+    const billingRequest = nock("https://api.billing.stedi.com")
+      .get(/\/2021-09-01\/usage/)
+      .once()
+      .reply(200, { subtotal: 350 });
+
+    const _result = await handler();
+
+    t.assert(billingRequest.isDone(), "fetched billing usage");
+    t.assert(
+      webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+  }
+);
+
+test.serial(
+  `only sends message to destination with the highest breached threshold`,
+  async (t) => {
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: configurationKey,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          destinations: [
+            {
+              threshold: 2_000,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING_2",
+                verb: "POST",
+              },
+            },
+            {
+              threshold: 500,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+            {
+              threshold: 200,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING_2",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies z.input<typeof ConfigurationSchema>,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => {
+        return (
+          body.threshold === 500 &&
+          // use range to account for developer machine timezone differences
+          body.estimatedUsage > 557 &&
+          body.estimatedUsage < 576
+        );
+      })
+      .once()
+      .reply(200, {});
+
+    const billingRequest = nock("https://api.billing.stedi.com")
+      .get(/\/2021-09-01\/usage/)
+      .once()
+      .reply(200, { subtotal: 350 });
+
+    const _result = await handler();
+
+    t.assert(billingRequest.isDone(), "fetched billing usage");
+    t.assert(
+      webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+  }
+);
+
+test.serial(
+  `does not send message when no threshold is breached`,
+  async (t) => {
+    stash
+      .on(GetValueCommand, {
+        keyspaceName: PARTNERS_KEYSPACE_NAME,
+        key: configurationKey,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          destinations: [
+            {
+              threshold: 2_000,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING_2",
+                verb: "POST",
+              },
+            },
+            {
+              threshold: 5_000,
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING_2",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies z.input<typeof ConfigurationSchema>,
+      });
+
+    const billingRequest = nock("https://api.billing.stedi.com")
+      .get(/\/2021-09-01\/usage/)
+      .once()
+      .reply(200, { subtotal: 350 });
+
+    const result = await handler();
+
+    t.assert(billingRequest.isDone(), "fetched billing usage");
+    t.assert(!result);
+  }
+);

--- a/src/optional-functions/billing/usage-poller/configuration.json
+++ b/src/optional-functions/billing/usage-poller/configuration.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "optional-functions/billing/usage-poller/configuration.json",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "destinations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "threshold": {
+            "description": "the",
+            "type": "number",
+            "minimum": 1
+          },
+          "destination": {
+            "oneOf": [
+              {
+                "$ref": "../../../schemas/destination-webhook.json"
+              },
+              {
+                "$ref": "../../../schemas/destination-function.json"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination",
+          "threshold"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "destinations"
+  ]
+}

--- a/src/optional-functions/billing/usage-poller/constants.ts
+++ b/src/optional-functions/billing/usage-poller/constants.ts
@@ -1,0 +1,1 @@
+export const configurationKey = "billing|usage";

--- a/src/optional-functions/billing/usage-poller/deploy.ts
+++ b/src/optional-functions/billing/usage-poller/deploy.ts
@@ -1,0 +1,61 @@
+import { GetValueCommand, SetValueCommand } from "@stedi/sdk-client-stash";
+import { stashClient } from "../../../lib/clients/stash.js";
+import { deployFunctionAtPath } from "../../../lib/functions.js";
+import { PARTNERS_KEYSPACE_NAME } from "../../../lib/constants.js";
+import { ConfigurationSchema } from "./Configuration.js";
+import dotenv from "dotenv";
+import { z } from "zod";
+import { configurationKey } from "./constants.js";
+
+const environmentVariables = dotenv.config().parsed ?? {};
+
+// change to root directory
+process.chdir(new URL("../../../..", import.meta.url).pathname);
+
+const functionName = "billing-usage-poller";
+
+console.log("deploying function");
+await deployFunctionAtPath(
+  "./src/optional-functions/billing/usage-poller/handler.ts",
+  functionName
+);
+
+const existingConfig = await stashClient().send(
+  new GetValueCommand({
+    keyspaceName: PARTNERS_KEYSPACE_NAME,
+    key: "billing|usage",
+  })
+);
+
+if (!existingConfig.value) {
+  console.log("deploying stash configuration");
+  if (!environmentVariables.DESTINATION_WEBHOOK_URL) {
+    console.warn(
+      `No DESTINATION_WEBHOOK_URL in .env file. Update Stash keyspace: ${PARTNERS_KEYSPACE_NAME}, key: ${configurationKey} with a destination to enable billing threshold alerts`
+    );
+  }
+  await stashClient().send(
+    new SetValueCommand({
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: configurationKey,
+      value: {
+        $schema:
+          "https://raw.githubusercontent.com/Stedi-Demos/bootstrap/main/src/optional-functions/billing/usage-poller/configuration.json",
+
+        destinations: process.env.DESTINATION_WEBHOOK_URL
+          ? [
+              {
+                threshold: 5_000,
+                destination: {
+                  type: "webhook",
+                  url: process.env.DESTINATION_WEBHOOK_URL,
+                },
+              },
+            ]
+          : [],
+      } satisfies z.input<typeof ConfigurationSchema>,
+    })
+  );
+}
+
+console.log("done");

--- a/src/optional-functions/billing/usage-poller/handler.ts
+++ b/src/optional-functions/billing/usage-poller/handler.ts
@@ -1,0 +1,108 @@
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { randomUUID } from "crypto";
+import fetch, { RequestInit } from "node-fetch";
+import { stashClient } from "../../../lib/clients/stash.js";
+import { PARTNERS_KEYSPACE_NAME } from "../../../lib/constants.js";
+import {
+  ProcessDeliveriesInput,
+  processDeliveries,
+} from "../../../lib/deliveryManager.js";
+import { requiredEnvVar } from "../../../lib/environment.js";
+import { ConfigurationSchema } from "./Configuration.js";
+import { configurationKey } from "./constants.js";
+
+interface UsageExceededPayload {
+  message: string;
+  threshold: number;
+  currentUsage: number;
+  estimatedUsage: number;
+}
+
+export const handler = async (): Promise<undefined | UsageExceededPayload> => {
+  const configurationResponse = await stashClient().send(
+    new GetValueCommand({
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: configurationKey,
+    })
+  );
+
+  if (!configurationResponse.value) {
+    console.log("no configuration for usage poller");
+    return;
+  }
+
+  const configuration = ConfigurationSchema.parse(configurationResponse.value);
+
+  const now = new Date();
+  const isoNow = now.toISOString();
+  const usageUrl = `https://api.billing.stedi.com/2021-09-01/usage?period=${encodeURIComponent(
+    isoNow
+  )}`;
+
+  const usageResponse = await fetch(usageUrl, {
+    headers: {
+      Authorization: `Key ${requiredEnvVar("STEDI_API_KEY")}`,
+      Accept: "application/json",
+    },
+  } satisfies RequestInit);
+
+  const { subtotal: usage } = (await usageResponse.json()) as {
+    subtotal: number;
+  };
+
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0);
+  const nextMonthStart = new Date(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    1,
+    0,
+    0,
+    0
+  );
+
+  // use 1 day as the minimum elapsed time to avoid calculating on a small spike
+  // at the beginning of the month which can lead to false positives
+  const pctTimeElapsedInMonth = Math.max(
+    0.03,
+    (now.getTime() - monthStart.getTime()) /
+      (nextMonthStart.getTime() - monthStart.getTime())
+  );
+
+  // assume no trend in usage
+  const smoothMonthEndExpectedUsage =
+    Math.round((usage / pctTimeElapsedInMonth) * 100) / 100;
+
+  const largestThresholdTriggered = configuration.destinations
+    .sort((a, b) => b.threshold - a.threshold)
+    .find((x) => x.threshold < smoothMonthEndExpectedUsage);
+
+  if (!largestThresholdTriggered) {
+    console.log("no threshold reached", {
+      currentUsage: usage,
+      estimatedUsage: smoothMonthEndExpectedUsage,
+    });
+    return;
+  }
+
+  const payload: UsageExceededPayload = {
+    message: "Expected month end usage exceeds configured threshold",
+    threshold: largestThresholdTriggered.threshold,
+    currentUsage: usage,
+    estimatedUsage: smoothMonthEndExpectedUsage,
+  };
+
+  console.log(payload);
+
+  const processDeliveriesInput: ProcessDeliveriesInput = {
+    destinations: [largestThresholdTriggered],
+    payload,
+    payloadMetadata: {
+      payloadId: randomUUID(),
+      format: "json",
+    },
+  };
+
+  await processDeliveries(processDeliveriesInput);
+
+  return payload;
+};

--- a/src/scripts/schema-zod-types.ts
+++ b/src/scripts/schema-zod-types.ts
@@ -6,6 +6,7 @@ import destinationFunction from "../schemas/destination-function.json" assert { 
 import destinationSftp from "../schemas/destination-sftp.json" assert { type: "json" };
 import destinationStash from "../schemas/destination-stash.json" assert { type: "json" };
 import destinationWebhook from "../schemas/destination-webhook.json" assert { type: "json" };
+import billingUsagePoller from "../optional-functions/billing/usage-poller/configuration.json" assert { type: "json" };
 import fs from "node:fs";
 import { jsonSchemaToZodDereffed } from "json-schema-to-zod";
 
@@ -18,6 +19,9 @@ await generateZod(destinationFunction, "DestinationFunction");
 await generateZod(destinationSftp, "DestinationSftp");
 await generateZod(destinationStash, "DestinationStash");
 await generateZod(destinationWebhook, "DestinationWebhook");
+// json-schema-to-zod dependency fix resolving child schemas
+process.chdir("../optional-functions/billing/usage-poller");
+await generateZod(billingUsagePoller, "Configuration", "./");
 
 async function generateZod(
   json: unknown,


### PR DESCRIPTION
Looks at the current billing period usage to project end-of-month costs. Triggers a webhook or function if the end-of-month costs are above a list of threshold spending levels.