### PR TITLE
fix: remote poller timestamp tracking

### DIFF
--- a/src/functions/ftp/external-poller/handler.ts
+++ b/src/functions/ftp/external-poller/handler.ts
@@ -145,7 +145,10 @@ const pollRemoteServer = async (
     // if remote file modifiedAt is not set, use current time
     const lastPollTimestamp = remotePollerConfig.lastPollTime?.getTime() ?? 0;
     const remoteFileTimestamp = file.lastModifiedTime;
-    if (remoteFileTimestamp < lastPollTimestamp) {
+    if (
+      !remotePollerConfig.ignoreFileTimestamps &&
+      remoteFileTimestamp < lastPollTimestamp
+    ) {
       ftpPollingResults.skippedItems.push({
         path: file.path,
         name: file.name,

--- a/src/functions/ftp/external-poller/types.ts
+++ b/src/functions/ftp/external-poller/types.ts
@@ -24,6 +24,7 @@ export interface ProcessingError {
 }
 
 export interface RemotePollingResults {
+  lastPollTime: Date;
   processedFiles: FileDetails[];
   skippedItems: SkippedItem[];
   processingErrors: ProcessingError[];

--- a/src/lib/types/RemoteConnectionConfig.ts
+++ b/src/lib/types/RemoteConnectionConfig.ts
@@ -35,6 +35,7 @@ export const RemotePollerConfigSchema = z.strictObject({
   remoteFiles: z.array(z.string()).optional(),
   destination: DestinationBucketSchema,
   deleteAfterProcessing: z.boolean().default(false),
+  ignoreFileTimestamps: z.boolean().default(false),
   lastPollTime: z
     .string()
     .optional()


### PR DESCRIPTION
- capture timestamp of current poll before retrieving file list (instead of at the end of processing)
- update timestamp of current poll operation if a file is encountered with a newer value than the currently tracked one (catch files that show up during processing somehow)
- add option for ignoring timestamps completely (always download the file, regardless of modification time)