### PR TITLE
feat: add property direction to only run destination in one direction

### DIFF
--- a/src/functions/edi/inbound/__tests__/handler.direction.ts
+++ b/src/functions/edi/inbound/__tests__/handler.direction.ts
@@ -1,0 +1,131 @@
+import test from "ava";
+import { handler } from "../handler.js";
+import nock from "nock";
+import { sampleTransactionProcessedEvent } from "../__fixtures__/events.js";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockGuideClient,
+  mockStashClient,
+  mockTranslateClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { GetObjectCommand } from "@stedi/sdk-client-buckets";
+import { Readable } from "stream";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import guideJSON855 from "../__fixtures__/855-guide.json" assert { type: "json" };
+import { TransactionSetDestinations } from "../../../../lib/types/Destination";
+
+const buckets = mockBucketClient();
+const translate = mockTranslateClient();
+const stash = mockStashClient();
+const guides = mockGuideClient();
+
+const partnershipId = "this-is-me_another-merchant";
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  nock.cleanAll();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  buckets.reset();
+  guides.reset();
+  stash.reset();
+  translate.reset();
+});
+
+test.serial(
+  `processes incoming transaction.processed event, do not deliver to destination when direction is outbound`,
+  async (t) => {
+    // loading incoming EDI file from S3
+    buckets.on(GetObjectCommand, {}).resolves({
+      body: sdkStreamMixin(
+        Readable.from([new TextEncoder().encode(JSON.stringify(guideJSON855))])
+      ),
+    });
+
+    stash
+      .on(GetValueCommand, {
+        key: `destinations|${partnershipId}|855`,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          description:
+            "Purchase Order Acknowledgments received from ANOTHERMERCH",
+          destinations: [
+            {
+              direction: "outbound",
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies TransactionSetDestinations,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => t.deepEqual(body, guideJSON855))
+      .reply(200, { thank: "you" });
+
+    const result = await handler(sampleTransactionProcessedEvent);
+
+    t.assert(
+      !webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+
+    t.deepEqual(result, {});
+  }
+);
+
+test.serial(
+  `processes incoming transaction.processed event, deliver to destination when direction is inbound`,
+  async (t) => {
+    // loading incoming EDI file from S3
+    buckets.on(GetObjectCommand, {}).resolves({
+      body: sdkStreamMixin(
+        Readable.from([new TextEncoder().encode(JSON.stringify(guideJSON855))])
+      ),
+    });
+
+    stash
+      .on(GetValueCommand, {
+        key: `destinations|${partnershipId}|855`,
+      }) // mock destinations lookup
+      .resolvesOnce({
+        value: {
+          description:
+            "Purchase Order Acknowledgments received from ANOTHERMERCH",
+          destinations: [
+            {
+              direction: "inbound",
+              destination: {
+                type: "webhook",
+                url: "https://webhook.site/TESTING",
+                verb: "POST",
+              },
+            },
+          ],
+        } satisfies TransactionSetDestinations,
+      });
+
+    // mock destination webhook delivery
+    const webhookRequest = nock("https://webhook.site")
+      .post("/TESTING", (body) => t.deepEqual(body, guideJSON855))
+      .reply(200, { thank: "you" });
+
+    const result = await handler(sampleTransactionProcessedEvent);
+
+    t.assert(
+      webhookRequest.isDone(),
+      "delivered guide JSON to destination webhook"
+    );
+
+    t.deepEqual(result, {});
+  }
+);

--- a/src/functions/edi/inbound/handler.ts
+++ b/src/functions/edi/inbound/handler.ts
@@ -128,7 +128,11 @@ export const ensureFileIsDeleted = async (bucketName: string, key: string) => {
 };
 
 const filterDestination = (
-  destination: { usageIndicatorCode?: string; release?: string },
+  destination: {
+    usageIndicatorCode?: string;
+    release?: string;
+    direction?: "inbound" | "outbound";
+  },
   envelopeData: { usageIndicatorCode: string; release: string }
 ) => {
   if (
@@ -139,6 +143,10 @@ const filterDestination = (
   }
 
   if (destination.release && envelopeData.release !== destination.release) {
+    return false;
+  }
+
+  if (destination.direction === "outbound") {
     return false;
   }
 

--- a/src/functions/edi/outbound/__tests__/handler.direction.ts
+++ b/src/functions/edi/outbound/__tests__/handler.direction.ts
@@ -1,0 +1,295 @@
+import test from "ava";
+import nock from "nock";
+import {
+  mockBucketClient,
+  mockExecutionTracking,
+  mockPartnersClient,
+  mockStashClient,
+  mockTranslateClient,
+} from "../../../../lib/testing/testHelpers.js";
+import { handler } from "../handler.js";
+import sampleOutboundEvent from "../../../../resources/X12/5010/850/outbound.json" assert { type: "json" };
+import {
+  GetX12PartnershipCommand,
+  GetX12PartnershipOutput,
+  GetX12ProfileCommand,
+  GetX12ProfileOutput,
+  IncrementX12ControlNumberCommand,
+  IncrementX12ControlNumberOutput,
+  Timezone,
+} from "@stedi/sdk-client-partners";
+import { GetValueCommand } from "@stedi/sdk-client-stash";
+import { PARTNERS_KEYSPACE_NAME } from "../../../../lib/constants.js";
+import { TransactionSetDestinations } from "../../../../lib/types/Destination.js";
+import {
+  TranslateJsonToX12Command,
+  TranslateJsonToX12Output,
+} from "@stedi/sdk-client-edi-translate";
+
+const buckets = mockBucketClient();
+const partners = mockPartnersClient();
+const stash = mockStashClient();
+const translate = mockTranslateClient();
+
+const guideId = "850-guide-id";
+const partnershipId = "this-is-me_another-merchant";
+
+test.beforeEach(() => {
+  nock.disableNetConnect();
+  mockExecutionTracking(buckets);
+});
+
+test.afterEach.always(() => {
+  buckets.reset();
+  partners.reset();
+  stash.reset();
+  translate.reset();
+});
+
+test.serial("skips delivery when direction is inbound", async (t) => {
+  partners
+    // load partnership
+    .on(GetX12PartnershipCommand as any, {
+      partnershipId,
+    })
+    .resolvesOnce({
+      partnershipId,
+      localProfileId: "this-is-me",
+      localProfile: {
+        interchangeQualifier: "ZZ",
+        interchangeId: "THISISME",
+        profileId: "this-is-me",
+        profileType: "local",
+      },
+      partnerProfileId: "another-merchant",
+      partnerProfile: {
+        interchangeQualifier: "14",
+        interchangeId: "ANOTHERMERCH",
+        profileId: "another-merchant",
+        profileType: "partner",
+      },
+      outboundTransactions: [
+        {
+          transactionSetIdentifier: "850",
+          outboundX12TransactionSettingsId: "850-transaction-rule-id",
+          guideId,
+          release: "008010",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      inboundTransactions: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      interchangeUsageIndicator: "T",
+      timezone: Timezone.AMERICA_NEW_YORK,
+    } satisfies GetX12PartnershipOutput as any)
+    // increment interchange control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "interchange",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "interchange",
+    } satisfies IncrementX12ControlNumberOutput as any)
+    // increment group control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "group",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "group",
+    } satisfies IncrementX12ControlNumberOutput as any)
+    .on(GetX12ProfileCommand as any, {
+      profileId: "this-is-me",
+    })
+    .resolvesOnce({
+      interchangeQualifier: "ZZ",
+      interchangeId: "THISISME",
+      profileId: "this-is-me",
+      profileType: "local",
+      defaultApplicationId: "meId",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies GetX12ProfileOutput as any)
+    .on(GetX12ProfileCommand as any, {
+      profileId: "another-merchant",
+    })
+    .resolvesOnce({
+      interchangeQualifier: "14",
+      interchangeId: "ANOTHERMERCH",
+      profileId: "another-merchant",
+      profileType: "partner",
+      defaultApplicationId: "merchId",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies GetX12ProfileOutput as any);
+
+  stash
+    // loading destinations
+    .on(GetValueCommand, {
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: `destinations|${partnershipId}|850`,
+    })
+    .resolvesOnce({
+      value: {
+        description: "850 Outbound",
+        destinations: [
+          {
+            destination: {
+              type: "webhook",
+              url: "https://example.com/webhook",
+            },
+          },
+          {
+            direction: "inbound",
+            destination: {
+              type: "webhook",
+              url: "https://example.com/webhook-not-called",
+            },
+          },
+        ],
+      } satisfies TransactionSetDestinations,
+    });
+
+  translate
+    // convert guide JSON to x12
+    .on(TranslateJsonToX12Command)
+    .resolvesOnce({ output: "ISA*" } satisfies TranslateJsonToX12Output);
+
+  // mock webhook request
+  const webhookRequest = nock("https://example.com")
+    .post("/webhook")
+    .reply(200, { ok: true });
+
+  const webhookRequestNotCalled = nock("https://example.com")
+    .post("/webhook-not-called")
+    .reply(200, { ok: true });
+
+  const response = await handler(sampleOutboundEvent as any);
+
+  t.is(response.statusCode, 200, "completes successfully");
+
+  t.assert(webhookRequest.isDone(), "webhook request was made");
+  t.assert(
+    !webhookRequestNotCalled.isDone(),
+    "production webhook is not called for test event"
+  );
+});
+
+test.serial("runs delivery when direction is outbound", async (t) => {
+  partners
+    // load partnership
+    .on(GetX12PartnershipCommand as any, {
+      partnershipId,
+    })
+    .resolvesOnce({
+      partnershipId,
+      localProfileId: "this-is-me",
+      localProfile: {
+        interchangeQualifier: "ZZ",
+        interchangeId: "THISISME",
+        profileId: "this-is-me",
+        profileType: "local",
+      },
+      partnerProfileId: "another-merchant",
+      partnerProfile: {
+        interchangeQualifier: "14",
+        interchangeId: "ANOTHERMERCH",
+        profileId: "another-merchant",
+        profileType: "partner",
+      },
+      outboundTransactions: [
+        {
+          transactionSetIdentifier: "850",
+          outboundX12TransactionSettingsId: "850-transaction-rule-id",
+          guideId,
+          release: "008010",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      inboundTransactions: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      interchangeUsageIndicator: "T",
+      timezone: Timezone.AMERICA_NEW_YORK,
+    } satisfies GetX12PartnershipOutput as any)
+    // increment interchange control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "interchange",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "interchange",
+    } satisfies IncrementX12ControlNumberOutput as any)
+    // increment group control number
+    .on(IncrementX12ControlNumberCommand as any, {
+      controlNumberType: "group",
+    })
+    .resolvesOnce({
+      x12ControlNumber: 1916,
+      controlNumberType: "group",
+    } satisfies IncrementX12ControlNumberOutput as any)
+    .on(GetX12ProfileCommand as any, {
+      profileId: "this-is-me",
+    })
+    .resolvesOnce({
+      interchangeQualifier: "ZZ",
+      interchangeId: "THISISME",
+      profileId: "this-is-me",
+      profileType: "local",
+      defaultApplicationId: "meId",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies GetX12ProfileOutput as any)
+    .on(GetX12ProfileCommand as any, {
+      profileId: "another-merchant",
+    })
+    .resolvesOnce({
+      interchangeQualifier: "14",
+      interchangeId: "ANOTHERMERCH",
+      profileId: "another-merchant",
+      profileType: "partner",
+      defaultApplicationId: "merchId",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies GetX12ProfileOutput as any);
+
+  stash
+    // loading destinations
+    .on(GetValueCommand, {
+      keyspaceName: PARTNERS_KEYSPACE_NAME,
+      key: `destinations|${partnershipId}|850`,
+    })
+    .resolvesOnce({
+      value: {
+        description: "850 Outbound",
+        destinations: [
+          {
+            direction: "outbound",
+            destination: {
+              type: "webhook",
+              url: "https://example.com/webhook",
+            },
+          },
+        ],
+      } satisfies TransactionSetDestinations,
+    });
+
+  translate
+    // convert guide JSON to x12
+    .on(TranslateJsonToX12Command)
+    .resolvesOnce({ output: "ISA*" } satisfies TranslateJsonToX12Output);
+
+  // mock webhook request
+  const webhookRequest = nock("https://example.com")
+    .post("/webhook")
+    .reply(200, { ok: true });
+
+  const response = await handler(sampleOutboundEvent as any);
+
+  t.is(response.statusCode, 200, "completes successfully");
+
+  t.assert(webhookRequest.isDone(), "webhook request was made");
+});

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -281,7 +281,11 @@ const validateTransactionSetControlNumbers = (guideJson: unknown) => {
 };
 
 const filterDestination = (
-  destination: { usageIndicatorCode?: string; release?: string },
+  destination: {
+    usageIndicatorCode?: string;
+    release?: string;
+    direction?: "inbound" | "outbound";
+  },
   event: { metadata: { usageIndicatorCode: string } },
   transactionSetConfig: { release: string }
 ) => {
@@ -296,6 +300,10 @@ const filterDestination = (
     destination.release &&
     transactionSetConfig.release !== destination.release
   ) {
+    return false;
+  }
+
+  if (destination.direction === "inbound") {
     return false;
   }
 

--- a/src/lib/types/Destination.ts
+++ b/src/lib/types/Destination.ts
@@ -31,6 +31,12 @@ const DestinationSchema = z.strictObject({
     .describe(
       "configure destination to receive the transaction set only when the envelope release matches the supplied value"
     ),
+  direction: z
+    .enum(["inbound", "outbound"])
+    .optional()
+    .describe(
+      "optional, the destination will only be used when the EDI document is in the specified direction. Used in edi-inbound and edi-outbound."
+    ),
   destination: z.discriminatedUnion("type", [
     DestinationAS2Schema,
     DestinationBucketSchema,

--- a/src/schemas/transaction-destinations.json
+++ b/src/schemas/transaction-destinations.json
@@ -41,6 +41,14 @@
             "minLength": 6,
             "maxLength": 12
           },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "inbound",
+              "outbound"
+            ],
+            "description": "optional, the destination will only be used when the EDI document is in the specified direction. Used in edi-inbound and edi-outbound."
+          },
           "destination": {
             "oneOf": [
               {


### PR DESCRIPTION
Add ability to use a destination for only one direction, "inbound" or "outbound", when the same transaction set is used for both sending and receiving in the same partnership. Property is optional and non-breaking change.