### PR TITLE
fix: upgrade partners sdk, change app id handling to reflect latest api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@stedi/sdk-client-functions": "^0.1.51",
         "@stedi/sdk-client-guides": "^0.1.51",
         "@stedi/sdk-client-mappings": "^0.1.51",
-        "@stedi/sdk-client-partners": "^0.1.51",
+        "@stedi/sdk-client-partners": "^0.2.19",
         "@stedi/sdk-client-queues": "^0.1.51",
         "@stedi/sdk-client-sftp": "^0.1.51",
         "@stedi/sdk-client-stash": "^0.1.51",
@@ -3446,9 +3446,9 @@
       }
     },
     "node_modules/@stedi/sdk-client-partners": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.1.52.tgz",
-      "integrity": "sha512-9TW3J+NnZto/Gg9LkGQBYU1F+W23KDk3WrDIZOM1YoL60b96QzN+U5tisEw4tkB0hQoiq95xSzj6CWX0S/0fVQ==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@stedi/sdk-client-partners/-/sdk-client-partners-0.2.19.tgz",
+      "integrity": "sha512-OtiGZxCclfwN70ylRgIqxNU2hwjASCqgGuSm0kbgzHMku7UopX7ymHIJQ+X9f3z62tg6kconDMBEPpXAkXYdyA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3461,7 +3461,6 @@
         "@aws-sdk/middleware-endpoint": "3.272.0",
         "@aws-sdk/middleware-host-header": "3.272.0",
         "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
         "@aws-sdk/middleware-retry": "3.272.0",
         "@aws-sdk/middleware-serde": "3.272.0",
         "@aws-sdk/middleware-stack": "3.272.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@stedi/sdk-client-functions": "^0.1.51",
     "@stedi/sdk-client-guides": "^0.1.51",
     "@stedi/sdk-client-mappings": "^0.1.51",
-    "@stedi/sdk-client-partners": "^0.1.51",
+    "@stedi/sdk-client-partners": "^0.2.19",
     "@stedi/sdk-client-queues": "^0.1.51",
     "@stedi/sdk-client-sftp": "^0.1.51",
     "@stedi/sdk-client-stash": "^0.1.51",

--- a/src/functions/edi/outbound/__tests__/handler.direction.ts
+++ b/src/functions/edi/outbound/__tests__/handler.direction.ts
@@ -108,7 +108,12 @@ test.serial("skips delivery when direction is inbound", async (t) => {
       interchangeId: "THISISME",
       profileId: "this-is-me",
       profileType: "local",
-      defaultApplicationId: "meId",
+      applicationIdentifiers: [
+        {
+          value: "meId",
+          isDefault: true,
+        },
+      ],
       createdAt: new Date(),
       updatedAt: new Date(),
     } satisfies GetX12ProfileOutput as any)
@@ -120,7 +125,12 @@ test.serial("skips delivery when direction is inbound", async (t) => {
       interchangeId: "ANOTHERMERCH",
       profileId: "another-merchant",
       profileType: "partner",
-      defaultApplicationId: "merchId",
+      applicationIdentifiers: [
+        {
+          value: "merchId",
+          isDefault: true,
+        },
+      ],
       createdAt: new Date(),
       updatedAt: new Date(),
     } satisfies GetX12ProfileOutput as any);
@@ -239,7 +249,12 @@ test.serial("runs delivery when direction is outbound", async (t) => {
       interchangeId: "THISISME",
       profileId: "this-is-me",
       profileType: "local",
-      defaultApplicationId: "meId",
+      applicationIdentifiers: [
+        {
+          value: "meId",
+          isDefault: true,
+        },
+      ],
       createdAt: new Date(),
       updatedAt: new Date(),
     } satisfies GetX12ProfileOutput as any)
@@ -251,7 +266,12 @@ test.serial("runs delivery when direction is outbound", async (t) => {
       interchangeId: "ANOTHERMERCH",
       profileId: "another-merchant",
       profileType: "partner",
-      defaultApplicationId: "merchId",
+      applicationIdentifiers: [
+        {
+          value: "merchId",
+          isDefault: true,
+        },
+      ],
       createdAt: new Date(),
       updatedAt: new Date(),
     } satisfies GetX12ProfileOutput as any);

--- a/src/functions/edi/outbound/__tests__/handler.guideless-997.ts
+++ b/src/functions/edi/outbound/__tests__/handler.guideless-997.ts
@@ -56,7 +56,12 @@ test("translate 997 guide json without a guide and delivers to destination", asy
         interchangeId: "THISISME",
         profileId: "this-is-me",
         profileType: "local",
-        defaultApplicationId: "meId",
+        applicationIdentifiers: [
+          {
+            value: "meId",
+            isDefault: true,
+          },
+        ],
       },
       partnerProfileId: "another-merchant",
       partnerProfile: {
@@ -64,7 +69,12 @@ test("translate 997 guide json without a guide and delivers to destination", asy
         interchangeId: "ANOTHERMERCH",
         profileId: "another-merchant",
         profileType: "partner",
-        defaultApplicationId: "merchId",
+        applicationIdentifiers: [
+          {
+            value: "merchId",
+            isDefault: true,
+          },
+        ],
       },
       outboundTransactions: [
         {

--- a/src/functions/edi/outbound/__tests__/handler.legacy.ts
+++ b/src/functions/edi/outbound/__tests__/handler.legacy.ts
@@ -64,7 +64,12 @@ test("using legacy function input, it translates guide json to X12 and delivers 
         interchangeId: "THISISME",
         profileId: "this-is-me",
         profileType: "local",
-        defaultApplicationId: "meId",
+        applicationIdentifiers: [
+          {
+            value: "meId",
+            isDefault: true,
+          },
+        ],
       },
       partnerProfileId: "another-merchant",
       partnerProfile: {
@@ -72,7 +77,12 @@ test("using legacy function input, it translates guide json to X12 and delivers 
         interchangeId: "ANOTHERMERCH",
         profileId: "another-merchant",
         profileType: "partner",
-        defaultApplicationId: "merchId",
+        applicationIdentifiers: [
+          {
+            value: "merchId",
+            isDefault: true,
+          },
+        ],
       },
       outboundTransactions: [
         {

--- a/src/functions/edi/outbound/__tests__/handler.success-without-mapping.ts
+++ b/src/functions/edi/outbound/__tests__/handler.success-without-mapping.ts
@@ -60,7 +60,12 @@ test("translate guide json to X12 and delivers to destination", async (t) => {
         interchangeId: "THISISME",
         profileId: "this-is-me",
         profileType: "local",
-        defaultApplicationId: "meId",
+        applicationIdentifiers: [
+          {
+            value: "meId",
+            isDefault: true,
+          },
+        ],
       },
       partnerProfileId: "another-merchant",
       partnerProfile: {
@@ -68,7 +73,12 @@ test("translate guide json to X12 and delivers to destination", async (t) => {
         interchangeId: "ANOTHERMERCH",
         profileId: "another-merchant",
         profileType: "partner",
-        defaultApplicationId: "merchId",
+        applicationIdentifiers: [
+          {
+            value: "merchId",
+            isDefault: true,
+          },
+        ],
       },
       outboundTransactions: [
         {

--- a/src/functions/edi/outbound/handler.ts
+++ b/src/functions/edi/outbound/handler.ts
@@ -94,6 +94,20 @@ export const handler = async (
       })
     )) as { x12ControlNumber: number };
 
+    const applicationSenderCode =
+      transactionSetConfig.localApplicationId ??
+      partnership.localProfile.applicationIdentifiers?.find(
+        (appId) => appId.isDefault
+      )?.value ??
+      partnership.localProfile.interchangeId;
+
+    const applicationReceiverCode =
+      transactionSetConfig.partnerApplicationId ??
+      partnership.partnerProfile.applicationIdentifiers?.find(
+        (appId) => appId.isDefault
+      )?.value ??
+      partnership.partnerProfile.interchangeId;
+
     // Configure envelope data (interchange control header and functional group header) to combine with mapping result
     const envelope: EdiTranslateWriteEnvelope = {
       interchangeHeader: {
@@ -118,12 +132,8 @@ export const handler = async (
       },
       groupHeader: {
         functionalIdentifierCode: functionalIdentifierCode,
-        applicationSenderCode:
-          partnership.localProfile.defaultApplicationId ??
-          partnership.localProfile.interchangeId,
-        applicationReceiverCode:
-          partnership.partnerProfile.defaultApplicationId ??
-          partnership.partnerProfile.interchangeId,
+        applicationSenderCode,
+        applicationReceiverCode,
         date: formatInTimeZone(
           documentDate,
           partnership.timezone,

--- a/src/migrations/002-engine-preview.ts
+++ b/src/migrations/002-engine-preview.ts
@@ -239,6 +239,7 @@ export const up = async () => {
             release: guideTarget.release,
             transactionSetIdentifier: guideTarget.transactionSet,
             guideId,
+            outboundX12TransactionSettingsId: `${guideTarget.release}-${guideTarget.transactionSet}`,
           })
         );
       } else {

--- a/src/setup/bootstrap/createProfiles.ts
+++ b/src/setup/bootstrap/createProfiles.ts
@@ -33,14 +33,24 @@ export const createProfiles = async ({
     profileType: "local",
     interchangeQualifier: "ZZ",
     interchangeId: "THISISME",
-    defaultApplicationId: "THISISME",
+    applicationIdentifiers: [
+      {
+        value: "THISISME",
+        isDefault: true,
+      },
+    ],
   };
   const remoteProfile: CreateX12ProfileCommandInput = {
     profileId: "another-merchant",
     profileType: "partner",
     interchangeQualifier: "14",
     interchangeId: "ANOTHERMERCH",
-    defaultApplicationId: "ANOTHERMERCH",
+    applicationIdentifiers: [
+      {
+        value: "ANOTHERMERCH",
+        isDefault: true,
+      },
+    ],
   };
 
   console.log("Creating X12 Trading Partner Profile in Partners API");
@@ -176,6 +186,9 @@ const ensureOutboundTransaction = async ({
         release: guide.target!.release,
         transactionSetIdentifier: guide.target!.transactionSet,
         guideId: parseGuideId(guide.id!),
+        outboundX12TransactionSettingsId: `${guide.target!.release}-${
+          guide.target!.transactionSet
+        }`,
       };
     } else {
       transactionSet = "997";
@@ -183,6 +196,7 @@ const ensureOutboundTransaction = async ({
         partnershipId: partnership.partnershipId,
         release: "005010",
         transactionSetIdentifier: "997",
+        outboundX12TransactionSettingsId: "005010-997",
       };
     }
 


### PR DESCRIPTION
- upgrade partners SDK
- change GS ID (application ID) logic for `edi-outbound` to use the following process for choosing ID to use:
  - first, check outbound transaction configuration
  - second, check for a default application id for the profile
  - if neither of the above are set, use the same value as the ISA ID